### PR TITLE
feat: add update name endpoint

### DIFF
--- a/nicknamer/run_locally.sh
+++ b/nicknamer/run_locally.sh
@@ -4,7 +4,7 @@ set -e
 
 # Define the path to our binary and compose file.
 # Bazel places `data` dependencies in the same directory as the script.
-APP_BINARY="nicknamer/server/server"
+APP_BINARY="nicknamer/server/bin/bin"
 COMPOSE_FILE="nicknamer/compose.yaml"
 
 # Function to clean up containers on exit
@@ -30,5 +30,11 @@ done
 
 
 echo "--- Starting the application ---"
+# Set sensitive credentials as environment variables
+export DB_URL="postgres://user:password@localhost:5432/nicknamer"
+export ADMIN_USERNAME="admin"
+export ADMIN_PASSWORD="password"
+export JWT_SECRET="password"
+
 # Execute the actual application binary
-$APP_BINARY
+"$APP_BINARY"

--- a/nicknamer/server/lib/src/name/api/v1.rs
+++ b/nicknamer/server/lib/src/name/api/v1.rs
@@ -3,10 +3,10 @@ use crate::name::{Name, NameService};
 use crate::web::api::v1::ServerErrorResponse;
 use axum::{
     Router,
-    extract::{Query, State},
+    extract::{Path, Query, State},
     http::StatusCode,
     response::Json,
-    routing::get,
+    routing::{get, put},
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -62,6 +62,13 @@ pub struct CreateNameRequest {
     pub name: String,
     /// Server ID where the name is used
     pub server_id: String,
+}
+
+/// Request body for updating an existing name.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct UpdateNameRequest {
+    /// The new name/nickname
+    pub name: String,
 }
 
 /// Handler for GET /api/v1/names - Returns all names in JSON format.
@@ -162,9 +169,69 @@ pub async fn create_name_handler(
     }
 }
 
+/// Handler for PUT /api/v1/names/{discord_id}/servers/{server_id} - Updates an existing name.
+#[tracing::instrument(skip(state))]
+#[utoipa::path(
+    put,
+    path = "/api/v1/names/{discord_id}/servers/{server_id}",
+    params(
+        ("discord_id" = u64, Path, description = "Discord user ID associated with the name"),
+        ("server_id" = String, Path, description = "Server ID where the name is used")
+    ),
+    request_body = UpdateNameRequest,
+    responses(
+        (status = 200, description = "Successfully updated name", body = NameJson),
+        (status = 400, description = "Bad request", body = ServerErrorResponse),
+        (status = 404, description = "Name not found for this Discord ID and server", body = ServerErrorResponse),
+        (status = 500, description = "Internal server error", body = ServerErrorResponse)
+    ),
+    tag = "Names"
+)]
+pub async fn update_name_by_discord_server_handler(
+    State(state): State<Arc<NameState>>,
+    Path((discord_id, server_id)): Path<(u64, String)>,
+    Json(request): Json<UpdateNameRequest>,
+) -> Result<Json<NameJson>, (StatusCode, Json<ServerErrorResponse>)> {
+    let service = NameService::new(&state.db);
+
+    match service
+        .update_name_by_discord_server(discord_id, &server_id, request.name)
+        .await
+    {
+        Ok(updated_name) => Ok(Json(NameJson::from(updated_name))),
+        Err(crate::name::NameServiceError::NameNotFoundByDiscordServer(discord_id, server_id)) => {
+            tracing::warn!(
+                "Name not found for Discord ID {} in server {}",
+                discord_id,
+                server_id
+            );
+            Err((
+                StatusCode::NOT_FOUND,
+                Json(ServerErrorResponse::new(format!(
+                    "Name not found for Discord ID {} in server '{}'",
+                    discord_id, server_id
+                ))),
+            ))
+        }
+        Err(err) => {
+            tracing::error!("Failed to update name: {}", err);
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ServerErrorResponse::new(
+                    "Failed to update name".to_string(),
+                )),
+            ))
+        }
+    }
+}
+
 /// Creates and returns the names API router.
 pub fn create_api_router(state: Arc<NameState>) -> Router {
     Router::new()
         .route("/names", get(get_names_handler).post(create_name_handler))
+        .route(
+            "/names/{discord_id}/servers/{server_id}",
+            put(update_name_by_discord_server_handler),
+        )
         .with_state(state)
 }

--- a/nicknamer/server/lib/src/name/mod.rs
+++ b/nicknamer/server/lib/src/name/mod.rs
@@ -56,6 +56,9 @@ pub enum NameServiceError {
     /// Represents a name not found error.
     #[error("Name entry with ID {0} not found")]
     NameNotFound(u32),
+    /// Represents a name not found error by Discord ID and Server ID combination.
+    #[error("Name entry with Discord ID {0} and Server ID '{1}' not found")]
+    NameNotFoundByDiscordServer(u64, String),
     /// Represents malformed data error during bulk operations.
     #[error("Malformed data: {0}")]
     MalformedData(String),
@@ -335,5 +338,40 @@ impl NameService<'_> {
             .await?
             .ok_or(NameServiceError::NameNotFound(id))?;
         Ok(Name::from(name_model))
+    }
+
+    /// Updates a name entry by Discord ID and Server ID combination.
+    ///
+    /// # Arguments
+    ///
+    /// * `discord_id` - The Discord ID of the user.
+    /// * `server_id` - The Server ID where the name is used.
+    /// * `new_name` - The new name to set.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing the updated `Name` if successful, or an error otherwise.
+    #[tracing::instrument(skip(self))]
+    pub async fn update_name_by_discord_server(
+        &self,
+        discord_id: u64,
+        server_id: &str,
+        new_name: String,
+    ) -> Result<Name, NameServiceError> {
+        let name_to_update = name::Entity::find()
+            .filter(name::Column::DiscordId.eq(discord_id as i64))
+            .filter(name::Column::ServerId.eq(server_id))
+            .one(self.db)
+            .await?
+            .ok_or(NameServiceError::NameNotFoundByDiscordServer(
+                discord_id,
+                server_id.to_string(),
+            ))?;
+
+        let mut active_model: name::ActiveModel = name_to_update.into();
+        active_model.name = ActiveValue::Set(new_name.clone());
+        let updated_model = active_model.update(self.db).await?;
+
+        Ok(Name::from(updated_model))
     }
 }

--- a/nicknamer/server/lib/src/web/api.rs
+++ b/nicknamer/server/lib/src/web/api.rs
@@ -44,6 +44,7 @@ pub(crate) mod v1 {
             crate::auth::api::v1::json_login_handler,
             crate::name::api::v1::get_names_handler,
             crate::name::api::v1::create_name_handler,
+            crate::name::api::v1::update_name_by_discord_server_handler,
         ),
         components(
             schemas(
@@ -54,6 +55,7 @@ pub(crate) mod v1 {
                 crate::name::api::v1::NamesResponse,
                 crate::name::api::v1::NamesQuery,
                 crate::name::api::v1::CreateNameRequest,
+                crate::name::api::v1::UpdateNameRequest,
             )
         ),
         tags(

--- a/nicknamer/server/lib/tests/name_service_tests.rs
+++ b/nicknamer/server/lib/tests/name_service_tests.rs
@@ -968,3 +968,131 @@ async fn can_get_names_by_server_with_special_characters() {
     assert!(special_server_names.contains(&name1));
     assert!(!special_server_names.contains(&name2));
 }
+
+#[tokio::test]
+async fn can_update_name_by_discord_server_successfully() {
+    let state = setup().await.expect("Failed to setup test context");
+    let name_service = NameService::new(&state.db);
+
+    // Create a name using the service
+    let discord_id = 123456789u64;
+    let server_id = "test-server-123";
+    let original_name = "OriginalName";
+    let created_name = name_service
+        .create_name(discord_id, original_name.to_string(), server_id.to_string())
+        .await
+        .expect("Failed to create name");
+
+    // Verify the original name
+    assert_eq!(created_name.discord_id(), discord_id);
+    assert_eq!(created_name.name(), original_name);
+    assert_eq!(created_name.server_id(), server_id);
+
+    // Update the name using discord_id and server_id
+    let new_name = "UpdatedName";
+    let updated_name = name_service
+        .update_name_by_discord_server(discord_id, server_id, new_name.to_string())
+        .await
+        .expect("Failed to update name by discord server");
+
+    // Verify the update
+    assert_eq!(updated_name.id(), created_name.id()); // Same ID
+    assert_eq!(updated_name.discord_id(), discord_id);
+    assert_eq!(updated_name.name(), new_name); // Name changed
+    assert_eq!(updated_name.server_id(), server_id);
+}
+
+#[tokio::test]
+async fn can_handle_update_by_discord_server_when_not_found() {
+    let state = setup().await.expect("Failed to setup test context");
+    let name_service = NameService::new(&state.db);
+
+    // Try to update a name that doesn't exist
+    let result = name_service
+        .update_name_by_discord_server(999888777, "nonexistent-server", "NewName".to_string())
+        .await;
+
+    // Should return NameNotFoundByDiscordServer error
+    assert!(result.is_err());
+    let error = result.unwrap_err();
+    match error {
+        nicknamer_server::name::NameServiceError::NameNotFoundByDiscordServer(
+            discord_id,
+            server_id,
+        ) => {
+            assert_eq!(discord_id, 999888777);
+            assert_eq!(server_id, "nonexistent-server");
+        }
+        _ => panic!(
+            "Expected NameNotFoundByDiscordServer error, got: {:?}",
+            error
+        ),
+    }
+}
+
+#[tokio::test]
+async fn can_update_name_by_discord_server_with_special_characters() {
+    let state = setup().await.expect("Failed to setup test context");
+    let name_service = NameService::new(&state.db);
+
+    // Create a name
+    let discord_id = 444555666u64;
+    let server_id = "special-server!@#$%";
+    let original_name = "Original Name";
+    let created_name = name_service
+        .create_name(discord_id, original_name.to_string(), server_id.to_string())
+        .await
+        .expect("Failed to create name");
+
+    // Update with special characters in name
+    let new_name = "José María 🎮 with émojis & spëcial chars!";
+    let updated_name = name_service
+        .update_name_by_discord_server(discord_id, server_id, new_name.to_string())
+        .await
+        .expect("Failed to update name with special characters");
+
+    // Verify special characters are preserved
+    assert_eq!(updated_name.name(), new_name);
+    assert_eq!(updated_name.discord_id(), discord_id);
+    assert_eq!(updated_name.server_id(), server_id);
+}
+
+#[tokio::test]
+async fn can_update_name_by_discord_server_different_servers() {
+    let state = setup().await.expect("Failed to setup test context");
+    let name_service = NameService::new(&state.db);
+
+    let discord_id = 777888999u64;
+    let server1_id = "server-1";
+    let server2_id = "server-2";
+
+    // Create names for the same discord_id in different servers
+    let name1 = name_service
+        .create_name(discord_id, "Name1".to_string(), server1_id.to_string())
+        .await
+        .expect("Failed to create name in server1");
+
+    let name2 = name_service
+        .create_name(discord_id, "Name2".to_string(), server2_id.to_string())
+        .await
+        .expect("Failed to create name in server2");
+
+    // Update name in server1 only
+    let updated_name1 = name_service
+        .update_name_by_discord_server(discord_id, server1_id, "UpdatedName1".to_string())
+        .await
+        .expect("Failed to update name in server1");
+
+    // Verify server1 name was updated
+    assert_eq!(updated_name1.name(), "UpdatedName1");
+    assert_eq!(updated_name1.server_id(), server1_id);
+
+    // Verify server2 name was NOT changed
+    let unchanged_name2 = name_service
+        .get_name_by_id(name2.id())
+        .await
+        .expect("Failed to get name from server2");
+
+    assert_eq!(unchanged_name2.name(), "Name2"); // Original name preserved
+    assert_eq!(unchanged_name2.server_id(), server2_id);
+}

--- a/nicknamer/server/lib/tests/names_endpoints_tests.rs
+++ b/nicknamer/server/lib/tests/names_endpoints_tests.rs
@@ -1965,6 +1965,287 @@ pub mod api {
 
             assert_yaml_snapshot!(snapshot_data);
         }
+
+        #[tokio::test]
+        async fn can_update_name_by_discord_server_via_api() {
+            let state = setup().await.expect("Failed to setup test context");
+
+            let name_state = create_name_state(state.db);
+            let app = create_api_router(name_state.clone());
+
+            // First create a name via API
+            let create_data = serde_json::json!({
+                "discord_id": 123456789u64,
+                "name": "OriginalName",
+                "server_id": "test-server-123"
+            });
+            let create_request = Request::builder()
+                .method(Method::POST)
+                .uri("/names")
+                .header("content-type", "application/json")
+                .body(Body::from(create_data.to_string()))
+                .unwrap();
+
+            let create_response = app.oneshot(create_request).await.unwrap();
+            assert_eq!(create_response.status(), StatusCode::CREATED);
+
+            // Now update the name using our new endpoint
+            let update_data = serde_json::json!({
+                "name": "UpdatedName"
+            });
+            let app2 = create_api_router(name_state.clone());
+            let update_request = Request::builder()
+                .method(Method::PUT)
+                .uri("/names/123456789/servers/test-server-123")
+                .header("content-type", "application/json")
+                .body(Body::from(update_data.to_string()))
+                .unwrap();
+
+            let response = app2.oneshot(update_request).await.unwrap();
+
+            let status = response.status();
+            let headers = response.headers().clone();
+            let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            let body_text = std::str::from_utf8(&body).unwrap();
+
+            // Should return 200 OK
+            assert_eq!(status, StatusCode::OK);
+
+            // Parse and validate JSON structure
+            let json: Value = serde_json::from_str(body_text).expect("Should be valid JSON");
+            assert_eq!(json["discord_id"], 123456789);
+            assert_eq!(json["name"], "UpdatedName");
+            assert_eq!(json["server_id"], "test-server-123");
+            assert!(json["id"].is_number());
+
+            let snapshot_data = JsonApiResponseSnapshot::new(
+                body_text,
+                status,
+                &headers,
+                "api_v1_update_name_by_discord_server_success",
+            );
+
+            assert_yaml_snapshot!(snapshot_data);
+        }
+
+        #[tokio::test]
+        async fn cannot_update_nonexistent_name_by_discord_server_via_api() {
+            let state = setup().await.expect("Failed to setup test context");
+
+            let name_state = create_name_state(state.db);
+            let app = create_api_router(name_state.clone());
+
+            // Try to update a name that doesn't exist
+            let update_data = serde_json::json!({
+                "name": "NonexistentName"
+            });
+            let request = Request::builder()
+                .method(Method::PUT)
+                .uri("/names/999888777/servers/nonexistent-server")
+                .header("content-type", "application/json")
+                .body(Body::from(update_data.to_string()))
+                .unwrap();
+
+            let response = app.oneshot(request).await.unwrap();
+
+            let status = response.status();
+            let headers = response.headers().clone();
+            let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            let body_text = std::str::from_utf8(&body).unwrap();
+
+            // Should return 404 NOT FOUND
+            assert_eq!(status, StatusCode::NOT_FOUND);
+
+            // Parse and validate error response
+            let json: Value = serde_json::from_str(body_text).expect("Should be valid JSON");
+            assert!(json["error"].is_string());
+            assert!(
+                json["error"]
+                    .as_str()
+                    .unwrap()
+                    .contains("Name not found for Discord ID 999888777")
+            );
+
+            let snapshot_data = JsonApiResponseSnapshot::new(
+                body_text,
+                status,
+                &headers,
+                "api_v1_update_name_by_discord_server_not_found",
+            );
+
+            assert_yaml_snapshot!(snapshot_data);
+        }
+
+        #[tokio::test]
+        async fn can_update_name_by_discord_server_with_special_characters_via_api() {
+            let state = setup().await.expect("Failed to setup test context");
+
+            let name_state = create_name_state(state.db);
+            let app = create_api_router(name_state.clone());
+
+            // Create a name with special characters (using safe server ID for URL path)
+            let create_data = serde_json::json!({
+                "discord_id": 444555666u64,
+                "name": "OriginalName",
+                "server_id": "special-server-123"
+            });
+            let create_request = Request::builder()
+                .method(Method::POST)
+                .uri("/names")
+                .header("content-type", "application/json")
+                .body(Body::from(create_data.to_string()))
+                .unwrap();
+
+            let create_response = app.oneshot(create_request).await.unwrap();
+            assert_eq!(create_response.status(), StatusCode::CREATED);
+
+            // Update with special characters in name
+            let update_data = serde_json::json!({
+                "name": "José María 🎮 with émojis & spëcial chars!"
+            });
+            let app2 = create_api_router(name_state.clone());
+            let update_request = Request::builder()
+                .method(Method::PUT)
+                .uri("/names/444555666/servers/special-server-123")
+                .header("content-type", "application/json")
+                .body(Body::from(update_data.to_string()))
+                .unwrap();
+
+            let response = app2.oneshot(update_request).await.unwrap();
+
+            let status = response.status();
+            let headers = response.headers().clone();
+            let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            let body_text = std::str::from_utf8(&body).unwrap();
+
+            // Should return 200 OK
+            assert_eq!(status, StatusCode::OK);
+
+            // Parse and validate JSON structure with special characters
+            let json: Value = serde_json::from_str(body_text).expect("Should be valid JSON");
+            assert_eq!(json["discord_id"], 444555666);
+            assert_eq!(json["name"], "José María 🎮 with émojis & spëcial chars!");
+            assert_eq!(json["server_id"], "special-server-123");
+
+            let snapshot_data = JsonApiResponseSnapshot::new(
+                body_text,
+                status,
+                &headers,
+                "api_v1_update_name_by_discord_server_special_chars",
+            );
+
+            assert_yaml_snapshot!(snapshot_data);
+        }
+
+        #[tokio::test]
+        async fn can_update_same_discord_id_different_servers_via_api() {
+            let state = setup().await.expect("Failed to setup test context");
+
+            let name_state = create_name_state(state.db);
+            let app = create_api_router(name_state.clone());
+
+            let discord_id = 777888999u64;
+
+            // Create names for the same discord_id in different servers
+            let create_data1 = serde_json::json!({
+                "discord_id": discord_id,
+                "name": "Name1",
+                "server_id": "server-1"
+            });
+            let create_request1 = Request::builder()
+                .method(Method::POST)
+                .uri("/names")
+                .header("content-type", "application/json")
+                .body(Body::from(create_data1.to_string()))
+                .unwrap();
+
+            let create_response1 = app.oneshot(create_request1).await.unwrap();
+            assert_eq!(create_response1.status(), StatusCode::CREATED);
+
+            let app2 = create_api_router(name_state.clone());
+            let create_data2 = serde_json::json!({
+                "discord_id": discord_id,
+                "name": "Name2",
+                "server_id": "server-2"
+            });
+            let create_request2 = Request::builder()
+                .method(Method::POST)
+                .uri("/names")
+                .header("content-type", "application/json")
+                .body(Body::from(create_data2.to_string()))
+                .unwrap();
+
+            let create_response2 = app2.oneshot(create_request2).await.unwrap();
+            assert_eq!(create_response2.status(), StatusCode::CREATED);
+
+            // Update name in server-1 only
+            let update_data = serde_json::json!({
+                "name": "UpdatedName1"
+            });
+            let app3 = create_api_router(name_state.clone());
+            let update_request = Request::builder()
+                .method(Method::PUT)
+                .uri(&format!("/names/{}/servers/server-1", discord_id))
+                .header("content-type", "application/json")
+                .body(Body::from(update_data.to_string()))
+                .unwrap();
+
+            let response = app3.oneshot(update_request).await.unwrap();
+
+            let status = response.status();
+            let headers = response.headers().clone();
+            let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            let body_text = std::str::from_utf8(&body).unwrap();
+
+            // Should return 200 OK
+            assert_eq!(status, StatusCode::OK);
+
+            // Parse and validate that server-1 name was updated
+            let json: Value = serde_json::from_str(body_text).expect("Should be valid JSON");
+            assert_eq!(json["discord_id"], discord_id);
+            assert_eq!(json["name"], "UpdatedName1");
+            assert_eq!(json["server_id"], "server-1");
+
+            // Verify server-2 name was NOT changed by querying all names
+            let app4 = create_api_router(name_state.clone());
+            let get_request = Request::builder()
+                .method(Method::GET)
+                .uri("/names?server_id=server-2")
+                .body(Body::empty())
+                .unwrap();
+
+            let get_response = app4.oneshot(get_request).await.unwrap();
+            let get_body = axum::body::to_bytes(get_response.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            let get_body_text = std::str::from_utf8(&get_body).unwrap();
+            let get_json: Value =
+                serde_json::from_str(get_body_text).expect("Should be valid JSON");
+
+            // Server-2 should still have the original name
+            assert_eq!(get_json["count"], 1);
+            let server2_name = &get_json["names"][0];
+            assert_eq!(server2_name["discord_id"], discord_id);
+            assert_eq!(server2_name["name"], "Name2"); // Original name preserved
+            assert_eq!(server2_name["server_id"], "server-2");
+
+            let snapshot_data = JsonApiResponseSnapshot::new(
+                body_text,
+                status,
+                &headers,
+                "api_v1_update_name_different_servers",
+            );
+
+            assert_yaml_snapshot!(snapshot_data);
+        }
     }
 }
 

--- a/nicknamer/server/lib/tests/snapshots/tests_names_endpoints_tests_test__api__v1__can_update_name_by_discord_server_via_api.snap
+++ b/nicknamer/server/lib/tests/snapshots/tests_names_endpoints_tests_test__api__v1__can_update_name_by_discord_server_via_api.snap
@@ -1,0 +1,13 @@
+---
+source: .:2030
+expression: snapshot_data
+---
+status: 200
+headers:
+  content-type: application/json
+body:
+  discord_id: 123456789
+  id: 1
+  name: UpdatedName
+  server_id: test-server-123
+test_name: api_v1_update_name_by_discord_server_success

--- a/nicknamer/server/lib/tests/snapshots/tests_names_endpoints_tests_test__api__v1__can_update_name_by_discord_server_with_special_characters_via_api.snap
+++ b/nicknamer/server/lib/tests/snapshots/tests_names_endpoints_tests_test__api__v1__can_update_name_by_discord_server_with_special_characters_via_api.snap
@@ -1,0 +1,13 @@
+---
+source: .:2141
+expression: snapshot_data
+---
+status: 200
+headers:
+  content-type: application/json
+body:
+  discord_id: 444555666
+  id: 1
+  name: José María 🎮 with émojis & spëcial chars!
+  server_id: special-server-123
+test_name: api_v1_update_name_by_discord_server_special_chars

--- a/nicknamer/server/lib/tests/snapshots/tests_names_endpoints_tests_test__api__v1__can_update_same_discord_id_different_servers_via_api.snap
+++ b/nicknamer/server/lib/tests/snapshots/tests_names_endpoints_tests_test__api__v1__can_update_same_discord_id_different_servers_via_api.snap
@@ -1,0 +1,13 @@
+---
+source: .:2244
+expression: snapshot_data
+---
+status: 200
+headers:
+  content-type: application/json
+body:
+  discord_id: 777888999
+  id: 1
+  name: UpdatedName1
+  server_id: server-1
+test_name: api_v1_update_name_different_servers

--- a/nicknamer/server/lib/tests/snapshots/tests_names_endpoints_tests_test__api__v1__cannot_update_nonexistent_name_by_discord_server_via_api.snap
+++ b/nicknamer/server/lib/tests/snapshots/tests_names_endpoints_tests_test__api__v1__cannot_update_nonexistent_name_by_discord_server_via_api.snap
@@ -1,0 +1,11 @@
+---
+source: .:2078
+expression: snapshot_data
+---
+status: 404
+headers:
+  content-type: application/json
+body:
+  error: "Name not found for Discord ID 999888777 in server 'nonexistent-server'"
+  message: "An error occurred: Name not found for Discord ID 999888777 in server 'nonexistent-server'"
+test_name: api_v1_update_name_by_discord_server_not_found


### PR DESCRIPTION
This pull request adds support for updating a user's name by Discord ID and server ID in the Nicknamer API and backend service. It introduces a new API endpoint for this functionality, updates the backend logic to handle name updates by Discord/server combination, and provides comprehensive tests for both the service and API layers. Additionally, it improves error handling for cases where a name entry is not found for the specified Discord ID and server.

### API and Service Enhancements

* Added a new `PUT /api/v1/names/{discord_id}/servers/{server_id}` endpoint to update a user's name for a specific Discord ID and server, including the handler `update_name_by_discord_server_handler` and the `UpdateNameRequest` request type. [[1]](diffhunk://#diff-58135964060041b70b123fdbba4ca4138035fe6a03ed3b5ab79a65c0415f1b9aL6-R9) [[2]](diffhunk://#diff-58135964060041b70b123fdbba4ca4138035fe6a03ed3b5ab79a65c0415f1b9aR67-R73) [[3]](diffhunk://#diff-58135964060041b70b123fdbba4ca4138035fe6a03ed3b5ab79a65c0415f1b9aR172-R235) [[4]](diffhunk://#diff-de8479cd0405f78c4db40e129939855c5845247b6d47dce7cc29eb23de438de8R47) [[5]](diffhunk://#diff-de8479cd0405f78c4db40e129939855c5845247b6d47dce7cc29eb23de438de8R58)
* Implemented the `update_name_by_discord_server` method in the `NameService` to update a name entry by Discord ID and server ID, and added a new error variant `NameNotFoundByDiscordServer` for improved error reporting. [[1]](diffhunk://#diff-77dab9c24ee4cd277890950568bb9d43f56ac362e151314f16b7cb1ae236e469R59-R61) [[2]](diffhunk://#diff-77dab9c24ee4cd277890950568bb9d43f56ac362e151314f16b7cb1ae236e469R342-R376)

### Testing Improvements

* Added comprehensive service-level tests for updating names by Discord/server, including success, not-found, handling special characters, and updating names for the same Discord ID in different servers.
* Added API endpoint tests to verify correct behavior for updating names, including success, not-found scenarios, special character handling, and updating names for the same Discord ID across different servers.

### Script and Environment Updates

* Updated the application binary path in `run_locally.sh` and added environment variable exports for sensitive credentials to support local development and testing. [[1]](diffhunk://#diff-1b39cf9244a6cd903d173d5730ee4a9a3affd84e3bc9986911605d74b13c2f02L7-R7) [[2]](diffhunk://#diff-1b39cf9244a6cd903d173d5730ee4a9a3affd84e3bc9986911605d74b13c2f02R33-R40)