### PR TITLE
fix: update RBE Bookworm image push command in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,4 +55,4 @@ jobs:
         run: bazel run --config=ci --compilation_mode=opt //nicknamer/server:push_image
       
       - name: Push RBE Bookworm Image
-        run: bazel run --config=ci --compilation_mode=opt //rbe-image/bookworm:push_image
+        run: bazel run --config=ci --compilation_mode=opt //rbe-image:push_image


### PR DESCRIPTION
This pull request makes a small update to the deployment workflow by changing the Bazel target used to push the RBE Bookworm image.

* Updated the Bazel run command in `.github/workflows/deploy.yml` to use the `//rbe-image:push_image` target instead of `//rbe-image/bookworm:push_image`.