### PR TITLE
feat: add tar dependency and configure shell link in rbe-image

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -36,6 +36,7 @@ bazel_dep(name = "toolchains_llvm", version = "1.5.0")
 bazel_dep(name = "rules_mypy", version = "0.40.0")
 bazel_dep(name = "rules_python", version = "1.6.3")
 bazel_dep(name = "rules_go", version = "0.58.2")
+bazel_dep(name = "tar.bzl", version = "0.6.0")
 bazel_dep(name = "gazelle", version = "0.45.0")
 bazel_dep(name = "platforms", version = "1.0.0")
 

--- a/rbe-image/BUILD.bazel
+++ b/rbe-image/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@rules_distroless//distroless:defs.bzl", "cacerts")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load", "oci_push")
+load("@tar.bzl", "tar")
 
 COMPATIBLE_WITH = select({
     "@platforms//cpu:x86_64": ["@platforms//cpu:x86_64"],
@@ -13,6 +14,14 @@ cacerts(
     name = "cacerts",
     package = "@rbe_image//ca-certificates:data",
     target_compatible_with = COMPATIBLE_WITH,
+)
+
+tar(
+    name = "sh",
+    mtree = [
+        # needed as dpkg assumes sh is installed in a typical debian installation.
+        "./bin/sh type=link link=/bin/bash",
+    ],
 )
 
 oci_image(
@@ -34,6 +43,7 @@ oci_image(
         # This target contains all the installed packages.
         "@rbe_image//:flat",
         ":cacerts",
+        ":sh",
     ],
 )
 


### PR DESCRIPTION
This pull request adds support for a symbolic link from `/bin/sh` to `/bin/bash` in the `rbe-image` build process to improve compatibility with Debian-based environments. It does this by introducing the `tar.bzl` Bazel dependency and using its `tar` rule to create the link. The new target is then included in the OCI image build.

**Dependency management:**

* Added `bazel_dep` for `tar.bzl` version `0.6.0` to `MODULE.bazel` to enable use of the `tar` rule.

**Build enhancements for image compatibility:**

* Loaded the `tar` rule from `tar.bzl` in `rbe-image/BUILD.bazel` to allow creation of custom tarballs.
* Defined a new `tar` target named `sh` that creates a symbolic link from `/bin/sh` to `/bin/bash`, addressing Debian compatibility requirements.
* Included the new `:sh` target in the list of layers for the OCI image, ensuring the symlink is present in the built container image.