### PR TITLE
ci: add gomodTidy to postUpdateOptions in renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,5 +10,6 @@
         "executionMode": "update"
       }
     }
-  ]
+  ],
+  "postUpdateOptions": ["gomodTidy"]
 }


### PR DESCRIPTION
This pull request makes a small configuration improvement to the `renovate.json` file by ensuring Go modules are tidied after updates. This helps keep the dependency files clean and up to date.

* Added `"postUpdateOptions": ["gomodTidy"]` to automatically run `go mod tidy` after dependency updates.