### PR TITLE
fix(predix): update apiUrl to production endpoint

### DIFF
--- a/angular/projects/predix/src/environments/environment.ts
+++ b/angular/projects/predix/src/environments/environment.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  apiUrl: 'http://localhost:8080',
+  apiUrl: 'https://predixbackend-production.up.railway.app',
 };


### PR DESCRIPTION
This pull request updates the backend API endpoint used in the production environment configuration. The change ensures the application connects to the deployed production backend service rather than a local development server.

* Updated the `apiUrl` in `environment.ts` to use the production backend URL (`https://predixbackend-production.up.railway.app`) instead of the local development server (`http://localhost:8080`).