### PR TITLE
chore: add target to .bazelignore

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,1 +1,2 @@
 node_modules
+target


### PR DESCRIPTION
This pull request makes a minor update to the Bazel configuration by adding the `target` directory to `.bazelignore`. This prevents Bazel from indexing or acting on files in the `target` directory, which can help improve build performance and avoid unnecessary processing.