### PR TITLE
build: use GO_TOOLs for bazel_env

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,6 +1,7 @@
 # BUILD file for Bazel tools and extensions
 load("@bazel_env.bzl", "bazel_env")
 load("@bazelrc-preset.bzl", "bazelrc_preset")
+load("@gazelle//:go_tools.bzl", "GO_TOOLS")
 load("@multitool//:tools.bzl", MULTITOOLS = "TOOLS")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//tools:@angular/cli/package_json.bzl", angular_cli = "bin")
@@ -47,13 +48,9 @@ bazel_env(
         "node": "$(NODE_PATH)",
         "pnpm": "@pnpm",
         "go": "@rules_go//go",
-        "scaffold": "@com_github_hay_kot_scaffold//:scaffold",
-        "gopls": "@org_golang_x_tools_gopls//:gopls",
-        "dlv": "@com_github_go_delve_delve//cmd/dlv:dlv",
-        "govulncheck": "@org_golang_x_vuln//cmd/govulncheck:govulncheck",
         "prettier": "//tools/format:prettier",
         "cargo": "@rules_rust//tools/upstream_wrapper:cargo",
-    } | LOCAL_TOOLS | MULTITOOLS,
+    } | LOCAL_TOOLS | MULTITOOLS | GO_TOOLS,
 )
 
 sh_binary(


### PR DESCRIPTION
This pull request updates the Bazel build configuration for tools, specifically improving how Go-related tools are managed. The changes streamline Go tool dependencies by consolidating their definitions and usage.

**Go tools dependency management:**

* Added the `GO_TOOLS` dependency from `@gazelle//:go_tools.bzl` and included it in the `bazel_env` toolset, replacing the previous explicit listing of individual Go tools like `scaffold`, `gopls`, `dlv`, and `govulncheck`. [[1]](diffhunk://#diff-0ab1e1c1585e240617dbd4a7eb3fe258f2ffc2b95f85a8fd35854996b58c1ccbR4) [[2]](diffhunk://#diff-0ab1e1c1585e240617dbd4a7eb3fe258f2ffc2b95f85a8fd35854996b58c1ccbL50-R53)