### PR TITLE
build(bazelrc): reorganize configuration options and update comments

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,16 +16,17 @@ common:remote-linux --platforms=@toolchains_buildbuddy//platforms:linux_x86_64
 common:remote-linux --extra_execution_platforms=@toolchains_buildbuddy//platforms:linux_x86_64
 common:remote-linux --jobs=50
 
-# For keep-sorted
-common --experimental_isolated_extension_usages
-# Ignore lockfile in CI
-common:ci --lockfile_mode="off"
+
 # Docs: https://registry.build/flag/bazel?filter=lockfile_mode
 
 # Show timeout warnings to correctly adjust build/test timeouts
 test --test_verbose_timeout_warnings
 
-run:quiet --ui_event_filters=-info,-stdout,-stderr --noshow_progress
+# For keep-sorted
+common --experimental_isolated_extension_usages
+
+# To always show a warning if githooks config is not correct
+common --workspace_status_command=githooks/check-config.sh
 
 # Disable skymeld; see https://github.com/bazelbuild/bazel/issues/23743
 # fixes src/main/tools/process-wrapper-legacy.cc:80: "execvp(external/++toolchains+coreutils_linux_amd64/coreutils, ...)": No such file or directory
@@ -46,11 +47,15 @@ common --@rules_python//python/config_settings:bootstrap_impl=script
 # --config=release
 common:release --stamp --workspace_status_command=./tools/workspace_status.sh
 
-common --workspace_status_command=githooks/check-config.sh
-
 # Don't depend on a JAVA_HOME pointing at a system JDK
 # see https://github.com/bazelbuild/rules_jvm_external/issues/445
 build --repo_env=JAVA_HOME=../bazel_tools/jdk
+
+# Ignore lockfile in CI
+common:ci --lockfile_mode="off"
+
+# To output something for xargs
+run:quiet --ui_event_filters=-info,-stdout,-stderr --noshow_progress
 
 # Load any settings & overrides specific to the current user.
 # This file should appear in `.gitignore` so that settings are not shared with team members. This


### PR DESCRIPTION
This pull request reorganizes and clarifies several configuration flags in the `.bazelrc` file, mainly to improve maintainability and ensure correct build and CI behavior. The changes focus on reordering certain flags, moving the lockfile and workspace status command settings to more appropriate sections, and ensuring that warnings and outputs are handled as intended.

Configuration reorganization and clarity:

* Moved the `--experimental_isolated_extension_usages` flag to group it with other related common flags for better organization.
* Relocated the `--lockfile_mode="off"` flag under the `common:ci` section to ensure it is only applied in CI environments.
* Moved the `--workspace_status_command=githooks/check-config.sh` flag to the main common section so that warnings about incorrect githooks configuration are always shown. [[1]](diffhunk://#diff-544556920c45b42cbfe40159b082ce8af6bd929e492d076769226265f215832fL19-R29) [[2]](diffhunk://#diff-544556920c45b42cbfe40159b082ce8af6bd929e492d076769226265f215832fL49-R59)

Output and warning improvements:

* Added a comment and moved the `run:quiet --ui_event_filters=-info,-stdout,-stderr --noshow_progress` flag to ensure output is properly suppressed and that something is output for `xargs`.