### PR TITLE
fix(predix): direct slog logger output to stdout

### DIFF
--- a/predix/app/main.go
+++ b/predix/app/main.go
@@ -121,7 +121,7 @@ func main() {
 	userHandler := userrest.NewHandler(userSvc, authManager)
 
 	r := gin.New()
-	r.Use(sloggin.SetLogger())
+	r.Use(sloggin.SetLogger(sloggin.WithWriter(os.Stdout)))
 	r.Use(gin.Recovery())
 	r.SetTrustedProxies(nil)
 


### PR DESCRIPTION
This pull request updates the logging configuration in the `predix/app/main.go` file to improve how logs are handled in the application.

Logging configuration:

* Changed the initialization of the logger middleware in the Gin router to explicitly set the log output to `os.Stdout` by using `sloggin.WithWriter(os.Stdout)` in the `SetLogger` call.