### PR TITLE
build(gazelle): switch to git override for gazelle_rust dependency

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -48,17 +48,11 @@ bazel_dep(name = "gazelle", version = "0.47.0")
 
 bazel_dep(name = "bazel_env.bzl", version = "0.5.0", dev_dependency = True)
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.9.0", dev_dependency = True)
-
-GAZELLE_RUST_COMMIT = "13d3e1277c4afef566310ae84dc0d2ba93e4d71a"
-
-GAZELLE_RUST_SHA256 = "sha256-Etkv2xNfgccuSuTP04E+J2rCrGnU7mo47ddhJoMXpjU="
-
-bazel_dep(name = "gazelle_rust", version = "0.1.0", dev_dependency = True)
-archive_override(
+bazel_dep(name = "gazelle_rust", dev_dependency = True)
+git_override(
     module_name = "gazelle_rust",
-    integrity = GAZELLE_RUST_SHA256,
-    strip_prefix = "gazelle_rust-{}".format(GAZELLE_RUST_COMMIT),
-    url = "https://github.com/Calsign/gazelle_rust/archive/{}.zip".format(GAZELLE_RUST_COMMIT),
+    commit = "13d3e1277c4afef566310ae84dc0d2ba93e4d71a",
+    remote = "https://github.com/Calsign/gazelle_rust.git",
 )
 
 # Use at HEAD version of rules_angular until 0.2.0 is released


### PR DESCRIPTION
This pull request updates the way the `gazelle_rust` dependency is managed in the `MODULE.bazel` file. Instead of using an archived release with a fixed version and SHA256 integrity check, it now pulls directly from a specific commit in the git repository using `git_override`. This allows for more precise control over the dependency version and simplifies the configuration.

Dependency management update:

* Changed the `gazelle_rust` dependency from an `archive_override` (with version, SHA256, and zip URL) to a `git_override` that pulls directly from a specific commit on GitHub. This removes the need for version and integrity variables, and ensures the dependency always points to the intended commit.