### PR TITLE
refactor(predix): decouple SSE subscription from service layer

### DIFF
--- a/predix/app/main.go
+++ b/predix/app/main.go
@@ -121,7 +121,7 @@ func main() {
 	go contestcloser.StartCloser(ctx, circleSvc, 10*time.Minute)
 
 	authManager := auth.NewManager(jwtSecret, 15*time.Minute)
-	circleHandler := circlerest.NewHandler(circleSvc)
+	circleHandler := circlerest.NewHandler(circleSvc, sseManager)
 	userHandler := userrest.NewHandler(userSvc, authManager)
 
 	r := gin.New()

--- a/predix/internal/domain/circle/rest/BUILD.bazel
+++ b/predix/internal/domain/circle/rest/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//predix/internal/auth",
         "//predix/internal/domain/circle",
         "//predix/internal/domain/circle/service",
+        "//predix/internal/domain/circle/sse",
         "//predix/internal/domain/contest",
         "//predix/internal/domain/user",
         "@com_github_gin_contrib_slog//:slog",

--- a/predix/internal/domain/circle/rest/handlers.go
+++ b/predix/internal/domain/circle/rest/handlers.go
@@ -15,18 +15,24 @@ import (
 	"github.com/lowkeylab/bazel-repo/predix/internal/auth"
 	"github.com/lowkeylab/bazel-repo/predix/internal/domain/circle"
 	"github.com/lowkeylab/bazel-repo/predix/internal/domain/circle/service"
+	"github.com/lowkeylab/bazel-repo/predix/internal/domain/circle/sse"
 	"github.com/lowkeylab/bazel-repo/predix/internal/domain/contest"
 	"github.com/lowkeylab/bazel-repo/predix/internal/domain/user"
 )
 
+type EventSubscriber interface {
+	Subscribe(contestID contest.ID) (chan sse.Event, func())
+}
+
 // Handler wires circle HTTP endpoints.
 type Handler struct {
-	svc *service.Service
+	svc        *service.Service
+	subscriber EventSubscriber
 }
 
 // NewHandler constructs a circle REST handler.
-func NewHandler(svc *service.Service) *Handler {
-	return &Handler{svc: svc}
+func NewHandler(svc *service.Service, subscriber EventSubscriber) *Handler {
+	return &Handler{svc: svc, subscriber: subscriber}
 }
 
 // RegisterRoutes registers circle routes on the provided router.
@@ -744,7 +750,7 @@ func (h *Handler) streamContestEvents(c *gin.Context) {
 	}
 
 	// Subscribe to events
-	events, unsubscribe := h.svc.SubscribeToContest(contestID)
+	events, unsubscribe := h.subscriber.Subscribe(contestID)
 	defer unsubscribe()
 
 	sloggin.Get(c).Info("client subscribed to contest events", "contest_id", contestID)

--- a/predix/internal/domain/circle/rest/handlers_test.go
+++ b/predix/internal/domain/circle/rest/handlers_test.go
@@ -53,8 +53,9 @@ func setupTestRouter(t *testing.T, sqlDB *sql.DB) (*gin.Engine, *service.Service
 	contestRepo := contestrepo.NewPostgres(sqlDB)
 	clk := clock.RealClock{}
 	txm := &TestTxManager{sqlDB: sqlDB}
-	svc := service.NewService(repo, userRepo, contestRepo, clk, txm, sse.NewManager())
-	handler := NewHandler(svc)
+	sseManager := sse.NewManager()
+	svc := service.NewService(repo, userRepo, contestRepo, clk, txm, sseManager)
+	handler := NewHandler(svc, sseManager)
 
 	r := gin.New()
 	r.Use(sloggin.SetLogger())

--- a/predix/internal/domain/circle/service/BUILD.bazel
+++ b/predix/internal/domain/circle/service/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//predix/internal/clock",
         "//predix/internal/domain/circle",
-        "//predix/internal/domain/circle/sse",
         "//predix/internal/domain/contest",
         "//predix/internal/domain/user",
     ],

--- a/predix/internal/domain/circle/service/service.go
+++ b/predix/internal/domain/circle/service/service.go
@@ -9,14 +9,12 @@ import (
 
 	"github.com/lowkeylab/bazel-repo/predix/internal/clock"
 	"github.com/lowkeylab/bazel-repo/predix/internal/domain/circle"
-	"github.com/lowkeylab/bazel-repo/predix/internal/domain/circle/sse"
 	"github.com/lowkeylab/bazel-repo/predix/internal/domain/contest"
 	"github.com/lowkeylab/bazel-repo/predix/internal/domain/user"
 )
 
 type EventListener interface {
 	OnEvent(event circle.DomainEvent)
-	Subscribe(contestID contest.ID) (chan sse.Event, func())
 }
 
 type CircleRepository interface {
@@ -64,11 +62,6 @@ func NewService(circleRepo CircleRepository, userRepo UserRepository, contestRep
 		txm:           txm,
 		eventListener: eventListener,
 	}
-}
-
-// SubscribeToContest subscribes to SSE events for a specific contest.
-func (s *Service) SubscribeToContest(contestID contest.ID) (chan sse.Event, func()) {
-	return s.eventListener.Subscribe(contestID)
 }
 
 var (


### PR DESCRIPTION
This pull request refactors how Server-Sent Events (SSE) subscriptions are managed for contest events in the circle domain. The main change is moving the responsibility for contest event subscriptions from the `Service` layer to the REST handler, improving separation of concerns and making the codebase more modular. The handler now directly interacts with the SSE manager via a new interface, and related code and dependencies have been updated accordingly.

**Refactoring SSE subscription management:**

* Added an `EventSubscriber` interface to `handlers.go`, and updated the `Handler` struct and its constructor (`NewHandler`) to accept an `EventSubscriber` instead of relying on the service for event subscriptions. (`predix/internal/domain/circle/rest/handlers.go`)
* Updated the event streaming endpoint to use the new `subscriber` field for subscribing to contest events, replacing the previous call to the service's subscription method. (`predix/internal/domain/circle/rest/handlers.go`)

**Dependency and import changes:**

* Added a dependency on `//predix/internal/domain/circle/sse` to the REST handler Bazel build file, and removed it from the service Bazel build file. (`predix/internal/domain/circle/rest/BUILD.bazel`, `predix/internal/domain/circle/service/BUILD.bazel`) [[1]](diffhunk://#diff-961830dd3edbc956a0fecccf6fce16ac70308b660584dab8a41d0f381d7a3f6eR12) [[2]](diffhunk://#diff-4bd89c8df0cfb02f7cb37d660b689f8b7056bb0dc25c46b5fe5381405a17ae1fL11)
* Updated imports in both handler and service files to reflect the change in SSE dependency. (`predix/internal/domain/circle/rest/handlers.go`, `predix/internal/domain/circle/service/service.go`) [[1]](diffhunk://#diff-049376dc9b8b74c18fc9c4491334c99333cde828ed3e1bd748b324b1b4cc29acR18-R35) [[2]](diffhunk://#diff-fcca55b52924de4cf99b21fb5e84dda0315c090b9cfd4b9de9092a59bb620c39L12-L19)

**Test and initialization updates:**

* Updated handler and service initialization in tests to pass the SSE manager directly to both the service and the handler, matching the new constructor signatures. (`predix/internal/domain/circle/rest/handlers_test.go`)

**Service API cleanup:**

* Removed the `SubscribeToContest` method from the `Service` type, as subscription logic now resides in the handler layer. (`predix/internal/domain/circle/service/service.go`)

**Main application wiring:**

* Updated the main application to pass the SSE manager to the circle REST handler during initialization. (`predix/app/main.go`)