### PR TITLE
build: add clippy

### DIFF
--- a/.aspect/cli/config.yaml
+++ b/.aspect/cli/config.yaml
@@ -20,3 +20,4 @@ lint:
     - //tools/lint:linters.bzl%ktlint
     - //tools/lint:linters.bzl%keep_sorted
     - //tools/lint:linters.bzl%stylelint
+    - //tools/lint:linters.bzl%clippy

--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,1 @@
+# See https://doc.rust-lang.org/clippy/configuration.html

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -24,6 +24,7 @@ exports_files(
         "pyproject.toml",
         ".editorconfig",
         ".ktlint-baseline.xml",
+        ".clippy.toml",
     ],
     visibility = [
         "//tools/format:__pkg__",

--- a/nicknamer/server/lib/src/auth/api/v1.rs
+++ b/nicknamer/server/lib/src/auth/api/v1.rs
@@ -38,15 +38,13 @@ pub async fn auth_user_middleware(
     mut request: Request,
     next: Next,
 ) -> Response {
-    if let Some(auth_header) = headers.get("authorization") {
-        if let Ok(auth_str) = auth_header.to_str() {
-            if let Some(token) = auth_str.strip_prefix("Bearer ") {
-                if let Ok(claims) = decode_jwt(token, &state.jwt_secret).await {
-                    let current_user = CurrentUser::new(claims.username);
-                    request.extensions_mut().insert(current_user);
-                }
-            }
-        }
+    if let Some(auth_header) = headers.get("authorization")
+        && let Ok(auth_str) = auth_header.to_str()
+        && let Some(token) = auth_str.strip_prefix("Bearer ")
+        && let Ok(claims) = decode_jwt(token, &state.jwt_secret).await
+    {
+        let current_user = CurrentUser::new(claims.username);
+        request.extensions_mut().insert(current_user);
     }
 
     next.run(request).await

--- a/nicknamer/server/lib/src/auth/mod.rs
+++ b/nicknamer/server/lib/src/auth/mod.rs
@@ -58,11 +58,11 @@ pub async fn auth_user_middleware(
     mut request: Request,
     next: Next,
 ) -> Response {
-    if let Some(token_cookie) = jar.get("auth_token") {
-        if let Ok(claims) = decode_jwt(token_cookie.value(), &state.jwt_secret).await {
-            let current_user = CurrentUser::new(claims.username);
-            request.extensions_mut().insert(current_user);
-        }
+    if let Some(token_cookie) = jar.get("auth_token")
+        && let Ok(claims) = decode_jwt(token_cookie.value(), &state.jwt_secret).await
+    {
+        let current_user = CurrentUser::new(claims.username);
+        request.extensions_mut().insert(current_user);
     }
 
     next.run(request).await

--- a/nicknamer/server/lib/src/name/mod.rs
+++ b/nicknamer/server/lib/src/name/mod.rs
@@ -80,7 +80,7 @@ impl From<name::Model> for Name {
 }
 
 impl NameService<'_> {
-    pub fn new(db: &sea_orm::DatabaseConnection) -> NameService {
+    pub fn new(db: &sea_orm::DatabaseConnection) -> NameService<'_> {
         NameService { db }
     }
 

--- a/nicknamer/server/lib/tests/names_endpoints_tests.rs
+++ b/nicknamer/server/lib/tests/names_endpoints_tests.rs
@@ -2188,7 +2188,7 @@ pub mod api {
             let app3 = create_api_router(name_state.clone());
             let update_request = Request::builder()
                 .method(Method::PUT)
-                .uri(&format!("/names/{}/servers/server-1", discord_id))
+                .uri(format!("/names/{}/servers/server-1", discord_id))
                 .header("content-type", "application/json")
                 .body(Body::from(update_data.to_string()))
                 .unwrap();

--- a/tools/lint/linters.bzl
+++ b/tools/lint/linters.bzl
@@ -2,6 +2,7 @@
 
 load("@aspect_rules_lint//lint:buf.bzl", "lint_buf_aspect")
 load("@aspect_rules_lint//lint:checkstyle.bzl", "lint_checkstyle_aspect")
+load("@aspect_rules_lint//lint:clippy.bzl", "lint_clippy_aspect")
 load("@aspect_rules_lint//lint:eslint.bzl", "lint_eslint_aspect")
 load("@aspect_rules_lint//lint:keep_sorted.bzl", "lint_keep_sorted_aspect")
 load("@aspect_rules_lint//lint:ktlint.bzl", "lint_ktlint_aspect")
@@ -62,4 +63,8 @@ keep_sorted = lint_keep_sorted_aspect(
 stylelint = lint_stylelint_aspect(
     binary = Label("//tools/lint:stylelint"),
     config = Label("//:stylelintrc"),
+)
+
+clippy = lint_clippy_aspect(
+    config = Label("//:.clippy.toml"),
 )


### PR DESCRIPTION
This pull request introduces support for Rust code linting with Clippy and refactors some Rust middleware for improved readability. The main changes are the addition of Clippy to the linting pipeline, configuration updates, and code simplification in authentication middleware.

### Linting and Build System Updates

* Added Clippy linter to the lint pipeline in `.aspect/cli/config.yaml`, `tools/lint/linters.bzl`, and defined the `clippy` target with configuration in `.clippy.toml` and `BUILD.bazel`. [[1]](diffhunk://#diff-7014c58e4126a578122528dee513aae0e37cace9517450170baabe1c9ebf6973R23) [[2]](diffhunk://#diff-55c6d3f9766a12b478c42c8f208f361f91d4c2e1cb892720b0502d3f72bc8fcfR5) [[3]](diffhunk://#diff-55c6d3f9766a12b478c42c8f208f361f91d4c2e1cb892720b0502d3f72bc8fcfR67-R70) [[4]](diffhunk://#diff-a70380a870c9f0bf3eae458f74d2fa061aa9073ad150114eab530504acae67f4R1) [[5]](diffhunk://#diff-7fc57714ef13c3325ce2a1130202edced92fcccc0c6db34a72f7b57f60d552a3R27)

### Rust Middleware Refactoring

* Refactored conditional logic in `auth_user_middleware` functions to use Rust's `&& let` syntax for more concise and readable code in both `nicknamer/server/lib/src/auth/api/v1.rs` and `nicknamer/server/lib/src/auth/mod.rs`. [[1]](diffhunk://#diff-7ee54deda72935dc3957166cba89bdd6ae735d6503ef9132e4a8dceba6ed9a55L41-L50) [[2]](diffhunk://#diff-e385b858977b0d243b9f26e6260313b8724d998580a15266761f9e32a9500a31L61-L66)

### Minor Fixes

* Corrected the lifetime annotation in the `NameService::new` constructor signature in `nicknamer/server/lib/src/name/mod.rs`.
* Simplified the URI formatting in a test in `nicknamer/server/lib/tests/names_endpoints_tests.rs`.