### PR TITLE
feat: Add /blog route to personal website

### DIFF
--- a/personal_website/src/BUILD.bazel
+++ b/personal_website/src/BUILD.bazel
@@ -13,6 +13,8 @@ copy_to_bin(
     ] + [
         "content.config.ts",
         "env.d.ts",
+    ]) + glob([
+        "utils/**",
     ]),
     visibility = ["//personal_website:__pkg__"],
 )

--- a/personal_website/src/components/Navbar.astro
+++ b/personal_website/src/components/Navbar.astro
@@ -2,7 +2,7 @@
 import ThemeToggle from "./ThemeToggle.astro";
 
 interface Props {
-  activeItem?: "home" | "projects" | "work" | "contact";
+  activeItem?: "home" | "projects" | "work" | "contact" | "blog";
 }
 
 const { activeItem = "home" } = Astro.props;
@@ -51,6 +51,11 @@ const isActive = (item: string) => activeItem === item;
             >
           </li>
           <li>
+            <a class={isActive("blog") ? "menu-active" : ""} href="/blog"
+              >Blog</a
+            >
+          </li>
+          <li>
             <a
               href="mailto:timdttran2000@gmail.com"
               target="_blank"
@@ -81,6 +86,11 @@ const isActive = (item: string) => activeItem === item;
           <li>
             <a class={isActive("work") ? "menu-active" : ""} href="/work"
               >Work</a
+            >
+          </li>
+          <li>
+            <a class={isActive("blog") ? "menu-active" : ""} href="/blog"
+              >Blog</a
             >
           </li>
           <li>

--- a/personal_website/src/content.config.ts
+++ b/personal_website/src/content.config.ts
@@ -31,7 +31,19 @@ const work = defineCollection({
   }),
 });
 
+const blog = defineCollection({
+  loader: glob({ pattern: "**/*.md", base: "./src/content/blog" }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    publishDate: z.coerce.date(),
+    tags: z.array(z.string()),
+    draft: z.boolean().optional().default(false),
+  }),
+});
+
 export const collections = {
   projects,
   work,
+  blog,
 };

--- a/personal_website/src/content/blog/hello-world.md
+++ b/personal_website/src/content/blog/hello-world.md
@@ -1,0 +1,21 @@
+---
+title: "Hello World"
+description: "My first blog post on my new blog"
+publishDate: 2026-02-18
+tags: ["intro", "personal"]
+draft: false
+---
+
+# Hello World
+
+Welcome to my new blog! This is a sample post to test the blog functionality.
+
+## Why a Blog?
+
+I decided to add a blog to share my thoughts on:
+
+- Software engineering
+- Personal projects
+- Learning new things
+
+Stay tuned for more posts!

--- a/personal_website/src/layouts/Layout.astro
+++ b/personal_website/src/layouts/Layout.astro
@@ -6,7 +6,7 @@ import Navbar from "../components/Navbar.astro";
 interface Props {
   title: string;
   description?: string;
-  activeItem?: "home" | "projects" | "contact" | "work";
+  activeItem?: "home" | "projects" | "contact" | "work" | "blog";
 }
 
 const {

--- a/personal_website/src/pages/blog/[slug].astro
+++ b/personal_website/src/pages/blog/[slug].astro
@@ -1,0 +1,52 @@
+---
+import { render } from "astro:content";
+import { getCollection } from "astro:content";
+import Layout from "../../layouts/Layout.astro";
+import { calculateReadingTime } from "../../utils/blog";
+
+export async function getStaticPaths() {
+  const posts = await getCollection("blog");
+  return posts.map((post) => ({
+    params: { slug: post.id },
+    props: { post },
+  }));
+}
+
+const { post } = Astro.props;
+const { Content } = await render(post);
+---
+
+<Layout
+  title={`${post.data.title} | Tim Tran`}
+  description={post.data.description}
+  activeItem="blog"
+>
+  <article class="max-w-4xl mx-auto">
+    <header class="mb-8">
+      <a href="/blog" class="text-sm text-primary hover:underline mb-4 inline-block">
+        ← Back to blog
+      </a>
+      <h1 class="text-4xl font-bold text-base-content mb-3 tracking-tight">
+        {post.data.title}
+      </h1>
+      <div class="flex items-center gap-4 text-base-content/60 mb-4">
+        <time datetime={post.data.publishDate.toISOString()}>
+          {new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'long', day: 'numeric' }).format(post.data.publishDate)}
+        </time>
+        <span>•</span>
+        <span>{calculateReadingTime(post.body || '')} min read</span>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        {post.data.tags.map(tag => (
+          <span class="px-2 py-0.5 text-[10px] font-bold rounded-full bg-primary/10 text-primary border border-primary/20 uppercase tracking-wide">
+            {tag}
+          </span>
+        ))}
+      </div>
+    </header>
+
+    <div class="prose prose-lg max-w-none">
+      <Content />
+    </div>
+  </article>
+</Layout>

--- a/personal_website/src/pages/blog/index.astro
+++ b/personal_website/src/pages/blog/index.astro
@@ -1,0 +1,62 @@
+---
+import Layout from "../../layouts/Layout.astro";
+import { getCollection } from "astro:content";
+import { calculateReadingTime } from "../../utils/blog";
+
+const allPosts = await getCollection("blog");
+const posts = allPosts
+  .filter((post) => !post.data.draft)
+  .sort((a, b) => b.data.publishDate.valueOf() - a.data.publishDate.valueOf());
+---
+
+<Layout
+  title="Blog | Tim Tran"
+  description="Thoughts on software engineering and more"
+  activeItem="blog"
+>
+  <header class="mb-12 text-center">
+    <h1 class="text-4xl font-bold text-base-content mb-3 tracking-tight">Blog</h1>
+    <p class="text-xl text-base-content/80 max-w-3xl mx-auto">
+      Thoughts on software engineering, projects, and learning.
+    </p>
+  </header>
+
+  <section class="space-y-10">
+    {posts.length === 0 ? (
+      <div class="text-center py-12">
+        <p class="text-lg text-base-content/60">No posts yet. Check back soon!</p>
+      </div>
+    ) : (
+      posts.map((post) => (
+        <div class="group relative">
+          <div class="absolute -inset-y-4 -inset-x-4 z-0 scale-95 bg-base-200 opacity-0 transition group-hover:scale-100 group-hover:opacity-100 sm:-inset-x-6 rounded-xl"></div>
+          <a href={`/blog/${post.id}`} class="relative z-10 flex flex-col items-start">
+            <div class="flex flex-col md:flex-row justify-between items-baseline w-full mb-1">
+              <h2 class="text-2xl font-bold text-primary group-hover:text-primary-focus transition-colors">
+                {post.data.title}
+              </h2>
+              <span class="text-xs font-medium opacity-60">
+                {new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'long', day: 'numeric' }).format(post.data.publishDate)}
+              </span>
+            </div>
+            <p class="text-lg text-base-content/80 leading-relaxed mb-4 max-w-4xl">
+              {post.data.description}
+            </p>
+            <div class="flex items-center gap-4 mb-3">
+              <span class="text-sm text-base-content/60">
+                {calculateReadingTime(post.body || '')} min read
+              </span>
+            </div>
+            <div class="flex flex-wrap gap-2">
+              {post.data.tags.map(tag => (
+                <span class="px-2 py-0.5 text-[10px] font-bold rounded-full bg-primary/10 text-primary border border-primary/20 uppercase tracking-wide">
+                  {tag}
+                </span>
+              ))}
+            </div>
+          </a>
+        </div>
+      ))
+    )}
+  </section>
+</Layout>

--- a/personal_website/src/utils/blog.ts
+++ b/personal_website/src/utils/blog.ts
@@ -1,0 +1,4 @@
+export function calculateReadingTime(content) {
+  const words = content.split(/\s+/).length;
+  return Math.ceil(words / 200);
+}


### PR DESCRIPTION
## Summary
- Added blog content collection to Astro with title, description, publishDate, tags, and draft support
- Created /blog index page with reverse chronological ordering, reading time, and tag display
- Created /blog/[slug] dynamic route for individual blog posts
- Added Blog link to navbar (both mobile and desktop)
- Added sample blog post to test functionality

## Test Plan
- [x] Build passes: `aspect build //personal_website:build`
- [x] Blog index renders at /blog
- [x] Individual posts render at /blog/[slug]
- [x] Navbar shows Blog as active when on blog pages