### PR TITLE
feat: migrate Angular macros to Bazel symbolic macros

### DIFF
--- a/3rdparty/rules_angular/BUILD.bazel
+++ b/3rdparty/rules_angular/BUILD.bazel
@@ -1,0 +1,3 @@
+exports_files([
+    "fix.patch",
+])

--- a/3rdparty/rules_angular/fix.patch
+++ b/3rdparty/rules_angular/fix.patch
@@ -1,0 +1,28 @@
+diff --git a/src/architect/ng_application.bzl b/src/architect/ng_application.bzl
+--- a/src/architect/ng_application.bzl
++++ b/src/architect/ng_application.bzl
+@@ -43,9 +43,9 @@ def ng_application(
+     project_name = project_name if project_name else name
+
+     ng_bin(
+-        name = "_%s.ng_cli" % name,
++        name = "%s_ng_cli" % name,
+         node_modules = node_modules,
+     )
+
+-    tool = ":_%s.ng_cli" % name
++    tool = ":%s_ng_cli" % name
+
+     js_run_binary(
+diff --git a/src/architect/utils.bzl b/src/architect/utils.bzl
+--- a/src/architect/utils.bzl
++++ b/src/architect/utils.bzl
+@@ -14,7 +14,7 @@ TEST_PATTERNS = [
+ # Reproduce the behavior of the logic a user would get from
+ # load("@npm//angular:@angular/cli/package_json.bzl", angular_cli = "bin")
+ def ng_entry_point(name, node_modules):
+-    entry_point_target = "_{}.ng_entry_point".format(name)
++    entry_point_target = "{}_ng_entry_point".format(name)
+     directory_path(
+         name = entry_point_target,
+         directory = "{}/@angular/cli/dir".format(node_modules),

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -63,6 +63,8 @@ bazel_dep(name = "rules_angular")
 git_override(
     module_name = "rules_angular",
     commit = "d746c4f75e42cffe389d1ab077f4639be2bc78d1",
+    patch_args = ["-p1"],
+    patches = ["//3rdparty/rules_angular:fix.patch"],
     remote = "https://github.com/devversion/rules_angular.git",
 )
 

--- a/angular/bzl/ng.bzl
+++ b/angular/bzl/ng.bzl
@@ -6,23 +6,11 @@ load("@npm//angular:postcss-cli/package_json.bzl", postcss_cli = "bin")
 load("@rules_angular//src/architect:ng_application.bzl", orig_ng_application = "ng_application")
 load("@rules_angular//src/architect:ng_test.bzl", orig_ng_test = "ng_test")
 
-def process_styles(name, src, out, config = "//angular:postcssrc", deps = [], **kwargs):
-    """
-    Processes a CSS file using PostCSS with Tailwind CSS support.
-
-    Args:
-        name: The name of the target.
-        src: The source CSS file.
-        out: The output CSS file.
-        config: The PostCSS configuration file (default: //angular:postcssrc).
-        deps: Additional dependencies (e.g., daisyui).
-        **kwargs: Additional arguments passed to js_run_binary (e.g. srcs for content scanning).
-    """
-    extra_srcs = kwargs.pop("srcs", [])
-
+def _process_styles_impl(name, visibility, src, out, config, deps, srcs):
     postcss_cli.postcss(
         name = name,
-        srcs = [src, config] + deps + extra_srcs + [
+        visibility = visibility,
+        srcs = [src, config] + deps + srcs + [
             "//angular:node_modules/@tailwindcss/postcss",
             "//angular:node_modules/postcss",
             "//angular:node_modules/tailwindcss",
@@ -37,16 +25,36 @@ def process_styles(name, src, out, config = "//angular:postcssrc", deps = [], **
         ],
     )
 
-def ng_application(zonejs = False, tailwindcss = False, deps = [], **kwargs):
-    """
-    Defines an ng_application with optional dependencies on zone.js and tailwindcss.
+process_styles = macro(
+    doc = "Processes a CSS file using PostCSS with Tailwind CSS support.",
+    implementation = _process_styles_impl,
+    attrs = {
+        "src": attr.label(
+            doc = "The source CSS file.",
+            configurable = False,
+        ),
+        "out": attr.output(
+            doc = "The output CSS file.",
+        ),
+        "config": attr.label(
+            doc = "The PostCSS configuration file.",
+            default = "//angular:postcssrc",
+            configurable = False,
+        ),
+        "deps": attr.label_list(
+            doc = "Additional dependencies (e.g., daisyui).",
+            default = [],
+            configurable = False,
+        ),
+        "srcs": attr.label_list(
+            doc = "Extra source files for content scanning.",
+            default = [],
+            configurable = False,
+        ),
+    },
+)
 
-    Args:
-        zonejs (bool): If True, includes zone.js as a dependency.
-        tailwindcss (bool): If True, includes tailwindcss and related packages as dependencies.
-        deps (list): Additional dependencies to include.
-        **kwargs: Additional keyword arguments passed to ng_application.
-    """
+def _ng_application_impl(name, visibility, zonejs, tailwindcss, deps, srcs):
     extra_deps = []
     if zonejs:
         extra_deps.append("//angular:node_modules/zone.js")
@@ -58,24 +66,42 @@ def ng_application(zonejs = False, tailwindcss = False, deps = [], **kwargs):
             "//angular:postcssrc",
         ]
     orig_ng_application(
+        name = name,
+        visibility = visibility,
+        srcs = srcs,
         deps = deps + extra_deps,
         ng_config = "//angular:ng-config",
         node_modules = "//angular:node_modules",
-        **kwargs
     )
 
-def ng_test(zonejs = False, tailwindcss = False, karma = False, vitest = False, deps = [], **kwargs):
-    """
-    Defines an ng_test with optional dependencies on zone.js and tailwindcss.
+ng_application = macro(
+    doc = "Defines an ng_application with optional dependencies on zone.js and tailwindcss.",
+    implementation = _ng_application_impl,
+    attrs = {
+        "zonejs": attr.bool(
+            doc = "If True, includes zone.js as a dependency.",
+            default = False,
+            configurable = False,
+        ),
+        "tailwindcss": attr.bool(
+            doc = "If True, includes tailwindcss and related packages as dependencies.",
+            default = False,
+            configurable = False,
+        ),
+        "deps": attr.label_list(
+            doc = "Additional dependencies to include.",
+            default = [],
+            configurable = False,
+        ),
+        "srcs": attr.label_list(
+            doc = "Source files.",
+            default = [],
+            configurable = False,
+        ),
+    },
+)
 
-    Args:
-        zonejs (bool): If True, includes zone.js as a dependency.
-        tailwindcss (bool): If True, includes tailwindcss and related packages as dependencies.
-        karma (bool): If True, includes karma as a dependency.
-        vitest (bool): If True, includes jsdom and vitest as dependencies.
-        deps (list): Additional dependencies to include.
-        **kwargs: Additional keyword arguments passed to ng_test.
-    """
+def _ng_test_impl(name, visibility, zonejs, tailwindcss, karma, vitest, deps, srcs):
     extra_deps = []
     if zonejs:
         extra_deps.append("//angular:node_modules/zone.js")
@@ -108,9 +134,48 @@ def ng_test(zonejs = False, tailwindcss = False, karma = False, vitest = False, 
         ]
 
     orig_ng_test(
+        name = name,
+        visibility = visibility,
+        srcs = srcs,
         deps = deps + extra_deps,
         ng_config = "//angular:ng-config",
         node_modules = "//angular:node_modules",
         size = "small",
-        **kwargs
     )
+
+ng_test = macro(
+    doc = "Defines an ng_test with optional dependencies on zone.js, tailwindcss, karma, and vitest.",
+    implementation = _ng_test_impl,
+    attrs = {
+        "zonejs": attr.bool(
+            doc = "If True, includes zone.js as a dependency.",
+            default = False,
+            configurable = False,
+        ),
+        "tailwindcss": attr.bool(
+            doc = "If True, includes tailwindcss and related packages as dependencies.",
+            default = False,
+            configurable = False,
+        ),
+        "karma": attr.bool(
+            doc = "If True, includes karma as a dependency.",
+            default = False,
+            configurable = False,
+        ),
+        "vitest": attr.bool(
+            doc = "If True, includes jsdom and vitest as dependencies.",
+            default = False,
+            configurable = False,
+        ),
+        "deps": attr.label_list(
+            doc = "Additional dependencies to include.",
+            default = [],
+            configurable = False,
+        ),
+        "srcs": attr.label_list(
+            doc = "Source files.",
+            default = [],
+            configurable = False,
+        ),
+    },
+)

--- a/angular/projects/mindreadr/BUILD.bazel
+++ b/angular/projects/mindreadr/BUILD.bazel
@@ -4,6 +4,11 @@ load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load", "oci_push")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("//angular/bzl:ng.bzl", "ng_application", "ng_test", "process_styles")
 
+exports_files([
+    "tsconfig.app.json",
+    "tsconfig.spec.json",
+])
+
 copy_to_bin(
     name = "srcs",
     srcs = glob(

--- a/angular/projects/nicknamer/BUILD.bazel
+++ b/angular/projects/nicknamer/BUILD.bazel
@@ -4,6 +4,11 @@ load("//angular/bzl:ng.bzl", "ng_application", "ng_test")
 # aspect:generation_mode update_only
 package(default_visibility = ["//visibility:public"])
 
+exports_files([
+    "tsconfig.app.json",
+    "tsconfig.spec.json",
+])
+
 copy_to_bin(
     name = "srcs",
     srcs = glob(
@@ -14,6 +19,7 @@ copy_to_bin(
 
 ng_application(
     name = "nicknamer",
+    srcs = [":srcs"],
     zonejs = True,
 )
 

--- a/angular/projects/nicknamer2-web/BUILD.bazel
+++ b/angular/projects/nicknamer2-web/BUILD.bazel
@@ -3,6 +3,11 @@ load("//angular/bzl:ng.bzl", "ng_application", "ng_test", "process_styles")
 
 package(default_visibility = ["//visibility:public"])
 
+exports_files([
+    "tsconfig.app.json",
+    "tsconfig.spec.json",
+])
+
 copy_to_bin(
     name = "srcs",
     srcs = glob(

--- a/angular/projects/predix/BUILD.bazel
+++ b/angular/projects/predix/BUILD.bazel
@@ -3,6 +3,11 @@ load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load", "oci_push")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("//angular/bzl:ng.bzl", "ng_application", "ng_test", "process_styles")
 
+exports_files([
+    "tsconfig.app.json",
+    "tsconfig.spec.json",
+])
+
 copy_to_bin(
     name = "srcs",
     srcs = glob(

--- a/angular/projects/tailwind-sample/BUILD.bazel
+++ b/angular/projects/tailwind-sample/BUILD.bazel
@@ -4,6 +4,11 @@ load("//angular/bzl:ng.bzl", "ng_application", "ng_test", "process_styles")
 # aspect:generation_mode update_only
 package(default_visibility = ["//visibility:public"])
 
+exports_files([
+    "tsconfig.app.json",
+    "tsconfig.spec.json",
+])
+
 copy_to_bin(
     name = "srcs",
     srcs = glob(


### PR DESCRIPTION
## Summary
- Convert `process_styles`, `ng_application`, and `ng_test` in `angular/bzl/ng.bzl` from legacy `def` macros to Bazel 9 symbolic macros with typed `attr.*` declarations
- Patch `rules_angular` to fix sub-target naming that violates symbolic macro naming rules (underscore-prefixed internal targets)
- Add `exports_files` for tsconfig files and explicit `srcs` to `nicknamer` to satisfy symbolic macro evaluation constraints

## Test plan
- [x] `aspect build //angular/...` passes (67 targets)
- [x] CI passes (`aspect lint //...` + `aspect test //...`)