### PR TITLE
chore: add .env to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ genhtml/
 
 # User-specific files
 user.bazelrc
+.env
 
 # Don't check in lockfile for now. It is unstable.
 # https://github.com/bazelbuild/bazel/issues/19026


### PR DESCRIPTION
## Summary
- Add `.env` to `.gitignore` to prevent accidental commits of local environment files
- `.envrc` already sources `.env` via `source_env_if_exists` for local use