### PR TITLE
chore: add .worktree/ to .bazelignore

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,2 +1,3 @@
 node_modules
 target
+.worktree/


### PR DESCRIPTION
## Summary
- Add `.worktree/` to `.bazelignore` so Bazel skips git worktree directories

## Test plan
- [x] Verify `aspect build //...` still succeeds