### PR TITLE
chore(renovate): update MODULE.bazel.lock after cargo dep updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,14 @@
         "fileFilters": ["maven_install.json"],
         "executionMode": "update"
       }
+    },
+    {
+      "matchManagers": ["cargo"],
+      "postUpgradeTasks": {
+        "commands": ["bazel mod deps --lockfile_mode=update"],
+        "fileFilters": ["MODULE.bazel.lock"],
+        "executionMode": "update"
+      }
     }
   ],
   "postUpdateOptions": ["gomodTidy"]


### PR DESCRIPTION
## Summary
- Add Renovate `postUpgradeTasks` for the `cargo` manager to run `bazel mod deps --lockfile_mode=update` after Cargo dependency updates
- Ensures `MODULE.bazel.lock` stays in sync since Cargo crates are loaded via `crate.from_cargo()` in `MODULE.bazel`