### PR TITLE
fix: coverage build failure and vite@7.3.2 manifest crash

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -77,6 +77,7 @@ test --test_verbose_timeout_warnings
 # Usage: bazel coverage //...
 # Or run: coverage (via bazel_env)
 coverage --combined_report=lcov
+coverage --build_tests_only
 coverage --instrumentation_filter="^//nicknamer[:/],^//nicknamer2[:/],^//mindreadr[:/],^//predix[:/],^//cowsay[:/],^//angular[:/]"
 
 # To output something for xargs

--- a/3rdparty/vite/vite@7.3.2.patch
+++ b/3rdparty/vite/vite@7.3.2.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/node/chunks/config.js b/dist/node/chunks/config.js
+index 2b39a20c497ee5c9f1cefdf1781df9955b50b97d..9559ab1fc0269f8fcf651a16dc4e07737894cd5b 100644
+--- a/dist/node/chunks/config.js
++++ b/dist/node/chunks/config.js
+@@ -29437,7 +29437,7 @@ function manifestPlugin() {
+ 				}
+ 				return manifestChunk;
+ 			}
+-			const entryCssReferenceIds = cssEntriesMap.get(this.environment);
++			const entryCssReferenceIds = cssEntriesMap.get(this.environment) ?? /* @__PURE__ */ new Map();
+ 			const entryCssAssetFileNames = /* @__PURE__ */ new Map();
+ 			for (const [name, id] of entryCssReferenceIds) try {
+ 				const fileName = this.getFileName(id);

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
       }
     },
     "patchedDependencies": {
-      "vite@7.3.1": "3rdparty/vite/vite@7.3.1.patch"
+      "vite@7.3.1": "3rdparty/vite/vite@7.3.1.patch",
+      "vite@7.3.2": "3rdparty/vite/vite@7.3.2.patch"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,6 +217,9 @@ patchedDependencies:
   vite@7.3.1:
     hash: 3a60c2100983d91d12d627c457b615458b67c5a8b1dce205f98c789854ec9a43
     path: 3rdparty/vite/vite@7.3.1.patch
+  vite@7.3.2:
+    hash: caabbe9f97c8c9ed6fb2dadfdcffbf08039814d81b94b9722fb9cdfda9246f10
+    path: 3rdparty/vite/vite@7.3.2.patch
 
 importers:
 
@@ -9590,8 +9593,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.5
       vfile: 6.0.3
-      vite: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(yaml@2.8.2)
-      vitefu: 1.1.3(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(yaml@2.8.2))
+      vite: 7.3.2(patch_hash=caabbe9f97c8c9ed6fb2dadfdcffbf08039814d81b94b9722fb9cdfda9246f10)(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(yaml@2.8.2)
+      vitefu: 1.1.3(vite@7.3.2(patch_hash=caabbe9f97c8c9ed6fb2dadfdcffbf08039814d81b94b9722fb9cdfda9246f10)(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(yaml@2.8.2))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.3.6
@@ -9683,8 +9686,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.5
       vfile: 6.0.3
-      vite: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(yaml@2.8.2)
-      vitefu: 1.1.3(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(yaml@2.8.2))
+      vite: 7.3.2(patch_hash=caabbe9f97c8c9ed6fb2dadfdcffbf08039814d81b94b9722fb9cdfda9246f10)(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(yaml@2.8.2)
+      vitefu: 1.1.3(vite@7.3.2(patch_hash=caabbe9f97c8c9ed6fb2dadfdcffbf08039814d81b94b9722fb9cdfda9246f10)(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(yaml@2.8.2))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.3.6
@@ -13368,7 +13371,7 @@ snapshots:
       sass: 1.97.3
       yaml: 2.8.2
 
-  vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(yaml@2.8.2):
+  vite@7.3.2(patch_hash=caabbe9f97c8c9ed6fb2dadfdcffbf08039814d81b94b9722fb9cdfda9246f10)(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -13399,9 +13402,9 @@ snapshots:
       sass: 1.97.3
       yaml: 2.8.2
 
-  vitefu@1.1.3(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(yaml@2.8.2)):
+  vitefu@1.1.3(vite@7.3.2(patch_hash=caabbe9f97c8c9ed6fb2dadfdcffbf08039814d81b94b9722fb9cdfda9246f10)(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(yaml@2.8.2)):
     optionalDependencies:
-      vite: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(yaml@2.8.2)
+      vite: 7.3.2(patch_hash=caabbe9f97c8c9ed6fb2dadfdcffbf08039814d81b94b9722fb9cdfda9246f10)(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(yaml@2.8.2)
 
   vitest@4.1.4(@types/node@24.12.2)(jsdom@29.0.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.2)):
     dependencies:


### PR DESCRIPTION
## Summary
- Add `coverage --build_tests_only` to `.bazelrc` to prevent `bazel coverage //...` from building non-test targets like `personal_website:build` (which fails in CI's local sandbox)
- Patch `vite@7.3.2` with the same `cssEntriesMap.get(this.environment) ?? new Map()` null-guard already applied to `vite@7.3.1`, fixing the `entryCssReferenceIds is not iterable` crash in Astro 6.1.6's build

## Test plan
- [x] `bazelisk build //personal_website:build` passes locally with the vite patch
- [x] `bazelisk coverage --build_tests_only --announce_rc` confirms the flag is picked up
- [x] CI coverage workflow passes