### PR TITLE
fix(renovate): scope maven pin task to maven datasource only

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
   "packageRules": [
     {
       "matchManagers": ["bazel"],
+      "matchDatasources": ["maven"],
       "postUpgradeTasks": {
         "commands": ["REPIN=1 bazel run @maven//:pin"],
         "fileFilters": ["maven_install.json"],

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": ["config:recommended", ":approveMajorUpdates", ":automergeAll"],
   "packageRules": [
     {
-      "matchManagers": ["bazel"],
+      "matchManagers": ["bazel-module"],
       "matchDatasources": ["maven"],
       "postUpgradeTasks": {
         "commands": ["REPIN=1 bazel run @maven//:pin"],


### PR DESCRIPTION
## Summary
- Add `matchDatasources: ["maven"]` to the bazel package rule in `renovate.json`
- Previously, `REPIN=1 bazel run @maven//:pin` ran for all bazel-managed dependency updates (Go, Rust, etc.), not just Java/Maven artifacts
