### PR TITLE
fix(renovate): use env command for REPIN variable in maven pin task

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
       "matchManagers": ["bazel-module"],
       "matchDatasources": ["maven"],
       "postUpgradeTasks": {
-        "commands": ["REPIN=1 bazel run @maven//:pin"],
+        "commands": ["env REPIN=1 bazel run @maven//:pin"],
         "fileFilters": ["maven_install.json"],
         "executionMode": "update"
       }


### PR DESCRIPTION
## Summary
- Renovate's `postUpgradeTasks` uses Node.js `child_process.spawn()`, which doesn't invoke a shell
- `REPIN=1 bazel run @maven//:pin` caused `spawn REPIN=1 ENOENT` because it treated `REPIN=1` as the executable name
- Prefixed with `env` so the environment variable is set correctly without needing a shell

## Test plan
- [ ] Verify Renovate can successfully update Java/Maven artifacts (e.g. `com.google.errorprone:error_prone_annotations`) without the `spawn REPIN=1 ENOENT` error