### PR TITLE
chore(nix): alias bazel to bazelisk in dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,7 @@
           default = pkgs.mkShell {
             packages = [
               pkgs.bazelisk
+              (pkgs.writeShellScriptBin "bazel" ''exec bazelisk "$@"'')
               pkgs.gcc
               pkgs.pre-commit
             ];


### PR DESCRIPTION
## Summary
- Add a `writeShellScriptBin` wrapper so `bazel` resolves to `bazelisk` inside the Nix dev shell
- More robust than a shell alias — works in scripts, subshells, and non-interactive contexts

## Test plan
- [x] `nix flake check` passes
- [x] `which bazel` resolves inside `nix develop`
- [x] `bazel --version` correctly invokes bazelisk
- [x] `bazelisk` still works independently