### PR TITLE
feat: enable coverage with remote execution via BuildBuddy

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -21,6 +21,7 @@ common:remote-linux --extra_execution_platforms=@toolchains_buildbuddy//platform
 common:remote-linux --jobs=50
 common:remote-linux --extra_toolchains=@buildbuddy_toolchain//:ubuntu_cc_toolchain
 common:remote-linux --host_platform=@toolchains_buildbuddy//platforms:linux_x86_64
+test:remote-linux --test_tag_filters=-no-remote
 
 # CI remote execution config (combines remote-linux with CI tuning)
 common:ci-remote --config=remote-linux
@@ -79,6 +80,13 @@ test --test_verbose_timeout_warnings
 coverage --combined_report=lcov
 coverage --build_tests_only
 coverage --instrumentation_filter="^//nicknamer[:/],^//nicknamer2[:/],^//mindreadr[:/],^//predix[:/],^//cowsay[:/],^//angular[:/]"
+
+# Coverage with remote execution: download toplevel outputs so coverage data
+# is available locally, and merge coverage reports with a local strategy
+coverage:remote-linux --remote_download_toplevel
+coverage:remote-linux --strategy=CoverageReport=local
+coverage:ci-remote --remote_download_toplevel
+coverage:ci-remote --strategy=CoverageReport=local
 
 # To output something for xargs
 run:quiet --ui_event_filters=-info,-stdout,-stderr --noshow_progress

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,8 +29,15 @@ jobs:
       - uses: browser-actions/setup-chrome@b94431e051d1c52dcbe9a7092a4f10f827795416
       - name: Install lcov
         run: sudo apt-get install -y lcov
-      - name: Run Coverage
+      - name: Run Coverage (remote)
         run: bazel run //tools/coverage -- //... --config=ci-remote
+      - name: Run Coverage (local-only tests)
+        run: |
+          bazel coverage //... --test_tag_filters=no-remote
+          LOCAL_DAT="$(bazel info output_path)/_coverage/_coverage_report.dat"
+          if [[ -f "$LOCAL_DAT" ]]; then
+            lcov --add-tracefile coverage-report.lcov --add-tracefile "$LOCAL_DAT" --output-file coverage-report.lcov
+          fi
       - name: Upload to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           bazel coverage //... --test_tag_filters=no-remote
           LOCAL_DAT="$(bazel info output_path)/_coverage/_coverage_report.dat"
-          if [[ -f "$LOCAL_DAT" ]]; then
+          if [[ -f "$LOCAL_DAT" ]] && lcov --summary "$LOCAL_DAT" &>/dev/null; then
             lcov --add-tracefile coverage-report.lcov --add-tracefile "$LOCAL_DAT" --output-file coverage-report.lcov
           fi
       - name: Upload to Codecov

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install lcov
         run: sudo apt-get install -y lcov
       - name: Run Coverage
-        run: bazel run //tools/coverage -- //...
+        run: bazel run //tools/coverage -- //... --config=ci-remote
       - name: Upload to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Run Bazel Lints
         run: |
           aspect lint //...
-      - name: Run Bazel tests
+      - name: Run Bazel tests (remote)
         run: |
           bazel test //... --config=ci-remote
+      - name: Run Bazel tests (local-only)
+        run: |
+          bazel test //... --test_tag_filters=no-remote

--- a/tools/coverage/coverage.sh
+++ b/tools/coverage/coverage.sh
@@ -23,13 +23,17 @@ if [[ -n "${BUILD_WORKSPACE_DIRECTORY:-}" ]]; then
 	cd "${BUILD_WORKSPACE_DIRECTORY}"
 fi
 
-TARGETS="${*:-//...}"
+if [ $# -eq 0 ]; then
+	ARGS=("//...")
+else
+	ARGS=("$@")
+fi
 REPORT_DIR="coverage-report"
 COMBINED_LCOV="coverage-report.lcov"
 COVERAGE_DAT="$(bazel info output_path)/_coverage/_coverage_report.dat"
 
-echo "==> Running bazel coverage for: ${TARGETS}"
-bazel coverage "${TARGETS}" 2>&1
+echo "==> Running bazel coverage for: ${ARGS[*]}"
+bazel coverage "${ARGS[@]}" 2>&1
 
 if [[ ! -f "${COVERAGE_DAT}" ]]; then
 	echo "ERROR: Combined coverage report not found at ${COVERAGE_DAT}"


### PR DESCRIPTION
## Summary
- Enable remote execution (`--config=ci-remote`) for CI coverage workflow, matching the existing test workflow
- Add `.bazelrc` configs for `coverage:remote-linux` and `coverage:ci-remote` with `--remote_download_toplevel` and `--strategy=CoverageReport=local`
- Filter Angular/karma tests from remote execution via `--test_tag_filters=-no-remote` (require browser unavailable in remote sandbox)
- Fix `coverage.sh` argument handling to properly pass `--config` flags through (was using `$*` instead of array)

## Context
Coverage CI previously ran locally while tests used remote execution via BuildBuddy, causing environment mismatches and slower builds. This was identified and validated via an autoresearch session that iterated through 6 approaches to find the working configuration.

Key findings:
- `CoverageReport` strategy must be `local` even with remote execution (report merging needs local file access)
- `--remote_download_toplevel` is required (same pattern as linting) so coverage data files are downloaded
- `--experimental_fetch_all_coverage_outputs` (already in `preset.bazelrc`) handles remote cache coverage downloads
- Angular karma tests fail with Exit 127 in remote sandbox due to missing browser — excluded via tag filter

## Test plan
- [ ] CI coverage workflow passes with remote execution enabled
- [ ] Coverage report is generated and uploaded to Codecov
- [ ] `bazel run //tools/coverage -- //... --config=ci-remote` works locally
- [ ] No regression in test workflow (`run-tests.yml`)