### PR TITLE
docs: make Nix dev shell the primary development setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,26 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Development Setup
+
+This repo uses a **Nix flake** for reproducible dev tooling. Nix provides `bazelisk`, `bazel`, `gcc`, and `pre-commit` — no manual installation needed.
+
+### Prerequisites
+
+- [Nix](https://nixos.org/download/) with flakes enabled (`experimental-features = nix-command flakes` in `~/.config/nix/nix.conf`)
+- [direnv](https://direnv.net/) >= 2.29
+- **NixOS only:** `programs.nix-ld.enable = true` in your NixOS configuration (needed for bazelisk to run downloaded Bazel binaries)
+
+### Getting started
+
+```bash
+direnv allow   # Enters Nix dev shell + sources .envrc
+```
+
+The `.envrc` automatically sources [nix-direnv](https://github.com/nix-community/nix-direnv) 3.1.1 for cached flake evaluations. After the first `direnv allow`, subsequent shell entries are near-instant.
+
+> **Note:** The Nix dev shell is not CI-validated. If `flake.nix` breaks, it will only be caught by developers using Nix. Bazel still works without Nix if you install `bazelisk` and `pre-commit` manually.
+
 ## Build System
 
 This is a **Bazel 9 polyglot monorepo** managed by Bazelisk. Use `aspect` (a Bazel wrapper) for build/test/lint. Never invoke `cargo`, `npm`, `go`, `mvn`, `pnpm`, or `ng` directly for building — all operations go through Bazel.
@@ -162,30 +182,9 @@ Angular 21 projects live in `angular/projects/` (mindreadr, nicknamer, predix, t
 
 ## Tooling
 
-- **pre-commit**: runs `format` and `buildifier-lint`. Install with `pre-commit install`.
+- **pre-commit**: runs `format` and `buildifier-lint` (provided by the Nix dev shell). Install hooks with `pre-commit install`.
 - **direnv/.envrc**: sources `.env`, sets PATH from `bazel-out`. Run `bazel run //tools:bazel_env` to populate.
 - **ibazel**: incremental Bazel for hot reload (e.g., `ibazel run //personal_website:dev`)
 - **rust-analyzer**: regenerate project with `bazel run //:gen_rust_project`
 - **Renovate**: automated dependency updates
 
-## Nix Development Shell (Optional)
-
-The repo includes a Nix flake for reproducible dev tooling. This is optional — existing workflows work without Nix.
-
-> **Note:** The Nix dev shell is not CI-validated. If `flake.nix` breaks, it will only be caught by developers using Nix.
-
-### Prerequisites
-- [Nix](https://nixos.org/download/) with flakes enabled (`experimental-features = nix-command flakes` in `~/.config/nix/nix.conf`)
-- [direnv](https://direnv.net/) >= 2.29
-- **NixOS only:** `programs.nix-ld.enable = true` in your NixOS configuration (needed for bazelisk to run downloaded Bazel binaries)
-
-### Usage
-```bash
-direnv allow   # Automatically enters Nix dev shell + existing .envrc setup
-```
-
-This provides `bazelisk` and `pre-commit` via Nix. All other tools come from Bazel (`bazel run //tools:bazel_env`).
-
-### Performance
-
-The `.envrc` automatically sources [nix-direnv](https://github.com/nix-community/nix-direnv) 3.1.1 for cached flake evaluations. After the first `direnv allow`, subsequent shell entries are near-instant.


### PR DESCRIPTION
## Summary
- Moved the Nix development shell section from an optional footnote to a top-level "Development Setup" section in CLAUDE.md
- `direnv allow` is now the recommended first step for new developers
- Noted that Bazel still works without Nix for non-Nix users
- Removed the duplicated "Nix Development Shell (Optional)" section at the bottom

## Test plan
- [x] Verify CLAUDE.md renders correctly on GitHub
- [x] Confirm `direnv allow` still works as documented