### PR TITLE
feat(nix): add agent-browser support to dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,11 @@
               (pkgs.writeShellScriptBin "bazel" ''exec bazelisk "$@"'')
               pkgs.gcc
               pkgs.pre-commit
+
+              # agent-browser: AI browser automation CLI (https://github.com/vercel-labs/agent-browser)
+              pkgs.nodejs # npm shim launcher for agent-browser
+            ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+              pkgs.chromium # hermetic browser — use with: agent-browser --executable-path $(which chromium)
             ];
 
             # Linux: set NIX_LD so bazelisk can run downloaded Bazel binaries
@@ -38,7 +43,38 @@
               NIX_LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
                 pkgs.stdenv.cc.cc.lib
                 pkgs.zlib
+
+                # Chrome/Chromium runtime deps for agent-browser
+                pkgs.libxcb
+                pkgs.libx11
+                pkgs.libxext
+                pkgs.libxrandr
+                pkgs.libxcomposite
+                pkgs.libxcursor
+                pkgs.libxdamage
+                pkgs.libxfixes
+                pkgs.libxi
+                pkgs.libxrender
+                pkgs.libxshmfence
+                pkgs.libxkbcommon
+                pkgs.gtk3
+                pkgs.pango
+                pkgs.at-spi2-atk
+                pkgs.at-spi2-core
+                pkgs.cairo
+                pkgs.gdk-pixbuf
+                pkgs.mesa
+                pkgs.libdrm
+                pkgs.alsa-lib
+                pkgs.dbus
+                pkgs.cups
+                pkgs.freetype
+                pkgs.fontconfig
+                pkgs.nss
+                pkgs.nspr
               ];
+              # Point agent-browser at Nix-provided Chromium
+              CHROME_PATH = "${pkgs.chromium}/bin/chromium";
             };
           };
         }

--- a/flake.nix
+++ b/flake.nix
@@ -73,8 +73,9 @@
                 pkgs.nss
                 pkgs.nspr
               ];
-              # Point agent-browser at Nix-provided Chromium
-              CHROME_PATH = "${pkgs.chromium}/bin/chromium";
+              # Point agent-browser at Nix-provided Chromium (Linux-only;
+              # on Darwin, agent-browser auto-detects Chrome from /Applications)
+              CHROME_PATH = pkgs.lib.getExe pkgs.chromium;
             };
           };
         }


### PR DESCRIPTION
## Summary
- Add `nodejs` and `chromium` packages to the Nix dev shell for [agent-browser](https://github.com/vercel-labs/agent-browser) support
- Add 20 Chrome/Chromium runtime shared libraries (X11, GTK, Mesa, NSS, ALSA, etc.) to `NIX_LD_LIBRARY_PATH`
- Set `CHROME_PATH` env var pointing at Nix-provided Chromium, avoiding the need for `agent-browser install`

## Test plan
- [x] `nix flake check --no-build` passes with no errors or warnings
- [x] Enter dev shell, run `npm install -g agent-browser`, verify `agent-browser` launches with Nix Chromium