### PR TITLE
feat(coverage): integrate JavaScript apps into Bazel coverage

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -73,6 +73,9 @@ common:lint --aspects=//tools/lint:linters.bzl%clippy
 
 # Show timeout warnings to correctly adjust build/test timeouts
 test --test_verbose_timeout_warnings
+# Pass CHROME_BIN from the host environment into the Bazel test sandbox
+# so karma-chrome-launcher can find the Chromium binary (e.g. from Nix).
+test --test_env=CHROME_BIN
 
 # Coverage configuration
 # Usage: bazel coverage //...

--- a/angular/BUILD.bazel
+++ b/angular/BUILD.bazel
@@ -64,3 +64,11 @@ js_library(
     tags = ["no-lint"],
     visibility = ["//angular:__subpackages__"],
 )
+
+js_library(
+    name = "karma-bazel-conf",
+    srcs = ["karma-bazel.conf.js"],
+    # prevent conflicting actions when linting
+    tags = ["no-lint"],
+    visibility = ["//angular:__subpackages__"],
+)

--- a/angular/angular.json
+++ b/angular/angular.json
@@ -65,6 +65,8 @@
         "test": {
           "builder": "@angular/build:karma",
           "options": {
+            "codeCoverage": true,
+            "karmaConfig": "karma-bazel.conf.js",
             "tsConfig": "projects/nicknamer/tsconfig.spec.json",
             "browsers": "ChromeHeadlessNoSandbox",
             "assets": [
@@ -140,6 +142,8 @@
         "test": {
           "builder": "@angular/build:karma",
           "options": {
+            "codeCoverage": true,
+            "karmaConfig": "karma-bazel.conf.js",
             "tsConfig": "projects/tailwind-sample/tsconfig.spec.json",
             "browsers": "ChromeHeadlessNoSandbox",
             "assets": [
@@ -223,6 +227,8 @@
         "test": {
           "builder": "@angular/build:karma",
           "options": {
+            "codeCoverage": true,
+            "karmaConfig": "karma-bazel.conf.js",
             "browsers": "ChromeHeadlessNoSandbox",
             "polyfills": ["zone.js", "zone.js/testing"],
             "tsConfig": "projects/mindreadr/tsconfig.spec.json",
@@ -302,6 +308,8 @@
         "test": {
           "builder": "@angular/build:karma",
           "options": {
+            "codeCoverage": true,
+            "karmaConfig": "karma-bazel.conf.js",
             "browsers": "ChromeHeadlessNoSandbox",
             "tsConfig": "projects/predix/tsconfig.spec.json",
             "assets": [
@@ -380,7 +388,10 @@
         "test": {
           "builder": "@angular/build:unit-test",
           "options": {
-            "tsConfig": "projects/nicknamer2-web/tsconfig.spec.json"
+            "tsConfig": "projects/nicknamer2-web/tsconfig.spec.json",
+            "coverage": true,
+            "coverageReporters": ["lcovonly"],
+            "runnerConfig": "projects/nicknamer2-web/vitest-base.config.ts"
           }
         }
       }

--- a/angular/bzl/ng.bzl
+++ b/angular/bzl/ng.bzl
@@ -115,6 +115,7 @@ def _ng_test_impl(name, visibility, zonejs, tailwindcss, karma, vitest, deps, sr
     if karma:
         extra_deps += [
             # keep-sorted start
+            "//angular:karma-bazel-conf",
             "//angular:node_modules/@types/jasmine",
             "//angular:node_modules/@types/node",
             "//angular:node_modules/jasmine-core",
@@ -128,6 +129,7 @@ def _ng_test_impl(name, visibility, zonejs, tailwindcss, karma, vitest, deps, sr
     if vitest:
         extra_deps += [
             # keep-sorted start
+            "//angular:node_modules/@vitest/coverage-v8",
             "//angular:node_modules/jsdom",
             "//angular:node_modules/vitest",
             # keep-sorted end

--- a/angular/karma-bazel.conf.js
+++ b/angular/karma-bazel.conf.js
@@ -1,0 +1,92 @@
+'use strict';
+// Karma configuration for Bazel coverage integration.
+//
+// When run via `bazel coverage`, this config:
+//   1. Writes lcov to a temp file via karma-coverage
+//   2. On process exit, rewrites SF: paths to workspace-relative form
+//      (e.g. src/app/app.ts → angular/projects/predix/src/app/app.ts)
+//      so Bazel's coverage aggregator finds them.
+//
+// When run outside bazel coverage (e.g. `bazel test` or `ng test`), writes
+// an HTML coverage report to a local coverage/ directory.
+
+const path = require('path');
+const fs = require('fs');
+
+module.exports = function (config) {
+  const coverageOutputFile = process.env['COVERAGE_OUTPUT_FILE'];
+
+  const baseConfig = {
+    basePath: '',
+    frameworks: ['jasmine'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+    ],
+    jasmineHtmlReporter: {
+      suppressAll: true,
+    },
+    reporters: ['progress', 'kjhtml'],
+    browsers: ['Chrome'],
+    customLaunchers: {
+      // Chrome configured to run in a Bazel sandbox.
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox', '--headless', '--disable-gpu', '--disable-dev-shm-usage'],
+      },
+    },
+    restartOnFileChange: true,
+  };
+
+  if (!coverageOutputFile) {
+    config.set({
+      ...baseConfig,
+      coverageReporter: {
+        dir: path.join(__dirname, 'coverage'),
+        subdir: '.',
+        reporters: [{ type: 'html' }, { type: 'text-summary' }],
+      },
+    });
+    return;
+  }
+
+  // In bazel coverage mode:
+  // - __dirname is <execroot>/angular/ (where this file lives)
+  // - process.cwd() is <execroot>/angular/projects/<project> (chdir from js_test)
+  // So path.relative(__dirname, '..') gives the Bazel workspace exec root, and
+  // path.relative(execRoot, cwd) gives the workspace-relative project path
+  // (e.g. "angular/projects/predix").
+  const execRoot = path.resolve(__dirname, '..');
+  const projectPrefix = path.relative(execRoot, process.cwd()); // e.g. "angular/projects/predix"
+  const tmpFile = coverageOutputFile + '.tmp.lcov';
+
+  config.set({
+    ...baseConfig,
+    coverageReporter: {
+      type: 'lcovonly',
+      dir: path.dirname(tmpFile),
+      file: path.basename(tmpFile),
+      subdir: '.',
+    },
+  });
+
+  // After karma finishes and coverage is written, rewrite SF: paths to
+  // workspace-relative form so Bazel's combined coverage report is correct.
+  process.on('exit', () => {
+    try {
+      if (!fs.existsSync(tmpFile)) return;
+      const raw = fs.readFileSync(tmpFile, 'utf8');
+      // Prepend projectPrefix to SF: lines that don't already start with /
+      // (i.e. relative paths like "src/app/app.ts" → "angular/projects/predix/src/app/app.ts")
+      const fixed = raw.replace(/^SF:(?!\/)/gm, `SF:${projectPrefix}/`);
+      fs.writeFileSync(coverageOutputFile, fixed);
+    } catch (_) {
+      // Fallback: copy raw file to avoid missing output
+      try {
+        fs.copyFileSync(tmpFile, coverageOutputFile);
+      } catch (_) {}
+    }
+  });
+};

--- a/angular/package.json
+++ b/angular/package.json
@@ -76,6 +76,7 @@
     "tailwindcss": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
     "vitest": "catalog:"
   }
 }

--- a/angular/projects/nicknamer2-web/BUILD.bazel
+++ b/angular/projects/nicknamer2-web/BUILD.bazel
@@ -19,6 +19,14 @@ copy_to_bin(
     ),
 )
 
+copy_to_bin(
+    name = "vitest_config_files",
+    srcs = [
+        "vitest-base.config.ts",
+        "vitest-global-setup.ts",
+    ],
+)
+
 process_styles(
     name = "processed_styles",
     src = "src/styles.css",
@@ -68,6 +76,7 @@ ng_test(
     srcs = [
         ":processed_styles",
         ":srcs",
+        ":vitest_config_files",
     ],
     tailwindcss = True,
     vitest = True,

--- a/angular/projects/nicknamer2-web/vitest-base.config.ts
+++ b/angular/projects/nicknamer2-web/vitest-base.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Write coverage to a known location relative to the config file so the
+// globalSetup teardown can reliably find it.
+const reportsDirectory = join(__dirname, '.vitest-coverage');
+
+export default defineConfig({
+  test: {
+    coverage: {
+      reportsDirectory,
+    },
+    // Always wire the global setup — teardown is a no-op when not under
+    // `bazel coverage` (checks COVERAGE_OUTPUT_FILE at runtime).
+    globalSetup: [join(__dirname, 'vitest-global-setup.ts')],
+  },
+});

--- a/angular/projects/nicknamer2-web/vitest-global-setup.ts
+++ b/angular/projects/nicknamer2-web/vitest-global-setup.ts
@@ -1,0 +1,29 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export async function teardown() {
+  const coverageOutputFile = process.env['COVERAGE_OUTPUT_FILE'];
+  // No-op when not running under `bazel coverage`.
+  if (!coverageOutputFile) return;
+
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const lcovSrc = join(__dirname, '.vitest-coverage', 'lcov.info');
+
+  if (!existsSync(lcovSrc)) {
+    process.stderr.write(`[vitest-coverage] lcov file not found at: ${lcovSrc}\n`);
+    return;
+  }
+
+  // The Angular CLI's vitest runner sets root=workspaceRoot (angular/), so
+  // coverage paths are relative to angular/ rather than the repo root.
+  // Bazel's instrumentation_filter and lcov aggregator expect paths prefixed
+  // with "angular/", so we rewrite SF: lines before emitting.
+  const content = readFileSync(lcovSrc, 'utf-8');
+  const fixed = content.replace(/^(SF:)(?!angular\/)/gm, '$1angular/');
+
+  mkdirSync(dirname(coverageOutputFile), { recursive: true });
+  writeFileSync(coverageOutputFile, fixed, 'utf-8');
+  const sfCount = fixed.split('\n').filter((l) => l.startsWith('SF:')).length;
+  process.stderr.write(`[vitest-coverage] Wrote ${sfCount} SF: entries to: ${coverageOutputFile}\n`);
+}

--- a/flake.nix
+++ b/flake.nix
@@ -74,8 +74,11 @@
                 pkgs.nspr
               ];
               # Point agent-browser at Nix-provided Chromium (Linux-only;
-              # on Darwin, agent-browser auto-detects Chrome from /Applications)
+              # on Darwin, agent-browser auto-detects Chrome from /Applications).
+              # CHROME_BIN is the same path under a different name — karma-chrome-launcher
+              # reads CHROME_BIN to locate the browser for `bazel coverage` on Karma tests.
               CHROME_PATH = pkgs.lib.getExe pkgs.chromium;
+              CHROME_BIN = pkgs.lib.getExe pkgs.chromium;
             };
           };
         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,27 @@ catalogs:
     '@angular/cli':
       specifier: 21.2.7
       version: 21.2.7
+    '@angular/common':
+      specifier: ^21.0.3
+      version: 21.2.9
+    '@angular/compiler':
+      specifier: ^21.0.3
+      version: 21.2.9
+    '@angular/compiler-cli':
+      specifier: ^21.0.2
+      version: 21.2.9
+    '@angular/core':
+      specifier: ^21.0.3
+      version: 21.2.9
+    '@angular/forms':
+      specifier: ^21.0.3
+      version: 21.2.9
+    '@angular/platform-browser':
+      specifier: ^21.0.3
+      version: 21.2.9
+    '@angular/router':
+      specifier: ^21.0.3
+      version: 21.2.9
     '@apollo/client':
       specifier: ^4.0.0
       version: 4.1.7
@@ -72,6 +93,9 @@ catalogs:
     '@typescript-eslint/parser':
       specifier: ^8.29.0
       version: 8.58.2
+    '@vitest/coverage-v8':
+      specifier: ^4.0.0
+      version: 4.1.4
     '@wry/caches':
       specifier: ^1.0.1
       version: 1.0.1
@@ -318,7 +342,7 @@ importers:
         version: 0.2102.5(chokidar@5.0.0)
       '@angular/build':
         specifier: 'catalog:'
-        version: 21.2.5(@angular/compiler-cli@21.2.9(@angular/compiler@21.2.9)(typescript@6.0.2))(@angular/compiler@21.2.9)(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.1)))(@types/node@24.12.2)(chokidar@5.0.0)(jiti@2.6.1)(karma@6.4.4)(lightningcss@1.32.0)(postcss@8.5.10)(tailwindcss@4.2.2)(tslib@2.8.1)(typescript@6.0.2)(vitest@4.1.4(@types/node@24.12.2)(jsdom@29.0.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3)))(yaml@2.8.3)
+        version: 21.2.5(@angular/compiler-cli@21.2.9(@angular/compiler@21.2.9)(typescript@6.0.2))(@angular/compiler@21.2.9)(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.1)))(@types/node@24.12.2)(chokidar@5.0.0)(jiti@2.6.1)(karma@6.4.4)(lightningcss@1.32.0)(postcss@8.5.10)(tailwindcss@4.2.2)(tslib@2.8.1)(typescript@6.0.2)(vitest@4.1.4)(yaml@2.8.3)
       '@angular/cli':
         specifier: 'catalog:'
         version: 21.2.7(@types/node@24.12.2)(chokidar@5.0.0)
@@ -355,6 +379,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.2
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.4(vitest@4.1.4)
       daisyui:
         specifier: 'catalog:'
         version: 5.5.19
@@ -396,7 +423,7 @@ importers:
         version: 8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.4(@types/node@24.12.2)(jsdom@29.0.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3))
+        version: 4.1.4(@types/node@24.12.2)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3))
 
   personal_website:
     dependencies:
@@ -838,6 +865,10 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
@@ -3081,6 +3112,15 @@ packages:
     peerDependencies:
       vite: ^6.0.0 || ^7.0.0
 
+  '@vitest/coverage-v8@4.1.4':
+    resolution: {integrity: sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==}
+    peerDependencies:
+      '@vitest/browser': 4.1.4
+      vitest: 4.1.4
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.4':
     resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
 
@@ -3273,6 +3313,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.0:
+    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
@@ -4587,6 +4630,9 @@ packages:
 
   js-pkce@2.0.0:
     resolution: {integrity: sha512-U7XEWBdI36P/977t6TC8zD2QdLlopiYy6SFG4tOojvuUSQsc4S7nH3vNUhzY5IgNwyyba/wfN0NbwEYeI31YXg==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -6935,7 +6981,7 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular/build@21.2.5(@angular/compiler-cli@21.2.9(@angular/compiler@21.2.9)(typescript@6.0.2))(@angular/compiler@21.2.9)(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.1)))(@types/node@24.12.2)(chokidar@5.0.0)(jiti@2.6.1)(karma@6.4.4)(lightningcss@1.32.0)(postcss@8.5.10)(tailwindcss@4.2.2)(tslib@2.8.1)(typescript@6.0.2)(vitest@4.1.4(@types/node@24.12.2)(jsdom@29.0.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3)))(yaml@2.8.3)':
+  '@angular/build@21.2.5(@angular/compiler-cli@21.2.9(@angular/compiler@21.2.9)(typescript@6.0.2))(@angular/compiler@21.2.9)(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.1)))(@types/node@24.12.2)(chokidar@5.0.0)(jiti@2.6.1)(karma@6.4.4)(lightningcss@1.32.0)(postcss@8.5.10)(tailwindcss@4.2.2)(tslib@2.8.1)(typescript@6.0.2)(vitest@4.1.4)(yaml@2.8.3)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2102.5(chokidar@5.0.0)
@@ -6975,7 +7021,7 @@ snapshots:
       lmdb: 3.5.1
       postcss: 8.5.10
       tailwindcss: 4.2.2
-      vitest: 4.1.4(@types/node@24.12.2)(jsdom@29.0.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3))
+      vitest: 4.1.4(@types/node@24.12.2)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3))
     transitivePeerDependencies:
       - '@types/node'
       - chokidar
@@ -7338,6 +7384,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@bramus/specificity@2.4.2':
     dependencies:
@@ -9287,6 +9335,20 @@ snapshots:
     dependencies:
       vite: 7.3.1(patch_hash=3a60c2100983d91d12d627c457b615458b67c5a8b1dce205f98c789854ec9a43)(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(yaml@2.8.3)
 
+  '@vitest/coverage-v8@4.1.4(vitest@4.1.4)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.4
+      ast-v8-to-istanbul: 1.0.0
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 4.0.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.4(@types/node@24.12.2)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3))
+
   '@vitest/expect@4.1.4':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -9513,6 +9575,12 @@ snapshots:
   array-union@2.1.0: {}
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   astral-regex@2.0.0: {}
 
@@ -11184,6 +11252,8 @@ snapshots:
   js-pkce@2.0.0:
     dependencies:
       crypto-js: 4.2.0
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -13397,7 +13467,7 @@ snapshots:
     optionalDependencies:
       vite: 7.3.2(patch_hash=caabbe9f97c8c9ed6fb2dadfdcffbf08039814d81b94b9722fb9cdfda9246f10)(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(yaml@2.8.3)
 
-  vitest@4.1.4(@types/node@24.12.2)(jsdom@29.0.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3)):
+  vitest@4.1.4(@types/node@24.12.2)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.4
       '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3))
@@ -13421,6 +13491,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.2
+      '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
       jsdom: 29.0.2
     transitivePeerDependencies:
       - msw

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -73,5 +73,6 @@ catalog:
   typescript: ~6.0.0
   typescript-eslint: ^8.49.0
   vite: ^8.0.0
+  '@vitest/coverage-v8': ^4.0.0
   vitest: ^4.0.0
   zone.js: ~0.16.0

--- a/tools/coverage/coverage.sh
+++ b/tools/coverage/coverage.sh
@@ -41,8 +41,13 @@ if [[ ! -f "${COVERAGE_DAT}" ]]; then
 	exit 1
 fi
 
-# Copy combined report with workspace-relative paths
+# Copy combined report with workspace-relative paths.
+# Make it user-writable so downstream lcov merges (e.g. CI's local-only
+# coverage step in .github/workflows/coverage.yml) can overwrite it; the
+# Bazel coverage dat in the cache is read-only, so a plain `cp` would
+# preserve those mode bits.
 cp "${COVERAGE_DAT}" "${COMBINED_LCOV}"
+chmod u+w "${COMBINED_LCOV}"
 echo "==> Combined lcov written to: ${COMBINED_LCOV}"
 
 # Generate HTML report if genhtml is available


### PR DESCRIPTION
## Summary

- Wires Karma (mindreadr, nicknamer, predix, tailwind-sample) and Vitest (nicknamer2-web) tests to emit lcov coverage that `bazel coverage` aggregates into the combined report. Previously `bazel coverage //angular/...` succeeded but produced 0 `SF:` entries for any JS project.
- Karma: shared `angular/karma-bazel.conf.js` writes lcov to `$COVERAGE_OUTPUT_FILE` (when set) and rewrites `SF:` paths to workspace-relative form so Bazel's combined report finds them. The `ng_test` macro pulls the config in via `//angular:karma-bazel-conf`.
- Vitest: `nicknamer2-web` switches to `@angular/build:unit-test` with `@vitest/coverage-v8` (`lcovonly`), plus a `globalSetup` teardown that rewrites `SF:` paths the same way.
- Env: `.bazelrc` passes `CHROME_BIN` into the test sandbox; `flake.nix` exports `CHROME_BIN` from the dev shell so `karma-chrome-launcher` finds Nix's Chromium without manual setup.

After this change, `tools/coverage/coverage.sh //angular/...` produces `coverage-report.lcov` with 45+ `SF:angular/projects/...` entries across all 5 Angular projects (mindreadr 14, nicknamer 14, predix 16, tailwind-sample 1, nicknamer2-web 13).

## Test plan
- [x] `bazel coverage //angular/...` — all 5 tests pass
- [x] `_coverage_report.dat` contains `SF:` entries for every Angular project (Karma + Vitest)
- [x] `bash tools/coverage/coverage.sh //angular/...` produces non-empty `coverage-report.lcov`
- [x] `bazel build //...` succeeds (no regressions)
- [x] `bazel run gazelle` produces no diffs
- [x] CI green