### PR TITLE
feat(renovate): add custom manager for multitool lockfile

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,24 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", ":approveMajorUpdates", ":automergeAll"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^tools/tools\\.lock\\.json$"],
+      "matchStrings": [
+        "\"url\":\\s*\"https://github\\.com/(?<depName>[^/]+/[^/]+)/releases/download/v(?<currentValue>[^/]+)/[^\"]*\""
+      ],
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^tools/tools\\.lock\\.json$"],
+      "matchStrings": [
+        "\"url\":\\s*\"https://releases\\.hashicorp\\.com/(?<depName>[^/]+)/(?<currentValue>[^/]+)/[^\"]*\""
+      ],
+      "datasourceTemplate": "hashicorp"
+    }
+  ],
   "packageRules": [
     {
       "matchManagers": ["bazel-module"],
@@ -17,6 +35,15 @@
         "commands": ["bazel mod deps --lockfile_mode=update"],
         "fileFilters": ["MODULE.bazel.lock"],
         "executionMode": "update"
+      }
+    },
+    {
+      "matchFileNames": ["tools/tools.lock.json"],
+      "groupName": "multitool managed tools",
+      "postUpgradeTasks": {
+        "commands": ["multitool --lockfile tools/tools.lock.json update"],
+        "fileFilters": ["tools/tools.lock.json"],
+        "executionMode": "branch"
       }
     }
   ],


### PR DESCRIPTION
## Summary
- Add Renovate custom regex managers to detect tool versions in `tools/tools.lock.json`:
  - `github-releases` datasource for 11 GitHub-hosted tools (buf, crane, buildozer, caddy, etc.)
  - `hashicorp` datasource for HashiCorp tools (terraform)
- Group all multitool-managed dependencies into a single PR via `groupName`
- Run `multitool --lockfile tools/tools.lock.json update` as a post-upgrade task to regenerate the lockfile with correct sha256 hashes

## Notes
- Covers all 12 tools in `tools/tools.lock.json`
- The Renovate runner needs `multitool` on PATH and `allowedPostUpgradeCommands` configured (see LowkeyLab/renovatebot#6)

## Test plan
- [ ] Verify Renovate detects the custom managers via the dependency dashboard
- [ ] Confirm GitHub-hosted tool versions are correctly extracted (e.g., `bufbuild/buf` at `1.63.0`)
- [ ] Confirm HashiCorp tool versions are correctly extracted (e.g., `terraform` at `1.9.3`)
- [ ] Validate that a grouped PR is created when upstream releases are available
- [ ] Verify `multitool update` runs and regenerates `tools/tools.lock.json` with correct hashes