### PR TITLE
feat(renovate): add custom manager for HashiCorp tools in multitool lockfile

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,16 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", ":approveMajorUpdates", ":automergeAll"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^tools/tools\\.lock\\.json$"],
+      "matchStrings": [
+        "\"url\":\\s*\"https://releases\\.hashicorp\\.com/(?<depName>[^/]+)/(?<currentValue>[^/]+)/[^\"]*\""
+      ],
+      "datasourceTemplate": "hashicorp"
+    }
+  ],
   "packageRules": [
     {
       "matchManagers": ["bazel-module"],
@@ -17,6 +27,15 @@
         "commands": ["bazel mod deps --lockfile_mode=update"],
         "fileFilters": ["MODULE.bazel.lock"],
         "executionMode": "update"
+      }
+    },
+    {
+      "matchFileNames": ["tools/tools.lock.json"],
+      "matchDatasources": ["hashicorp"],
+      "postUpgradeTasks": {
+        "commands": ["multitool --lockfile tools/tools.lock.json update"],
+        "fileFilters": ["tools/tools.lock.json"],
+        "executionMode": "branch"
       }
     }
   ],


### PR DESCRIPTION
## Summary
- Add a Renovate custom regex manager using the `hashicorp` datasource to detect HashiCorp tool versions (currently terraform at `1.9.3`) in `tools/tools.lock.json`
- Run `multitool --lockfile tools/tools.lock.json update` as a post-upgrade task to regenerate the lockfile with correct sha256 hashes
- Companion to #906 which covers the GitHub-hosted tools

## Notes
- Should be merged together with #906 to get full coverage of all tools in the lockfile
- Requires `multitool` on the Renovate runner PATH and `allowedPostUpgradeCommands` configured (see LowkeyLab/renovatebot#6)

## Test plan
- [ ] Verify Renovate detects terraform via the `hashicorp` datasource
- [ ] Confirm `multitool update` regenerates `tools/tools.lock.json` with correct hashes