### PR TITLE
fix(renovate): run multitool update through Bazel target

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -41,7 +41,7 @@
       "matchFileNames": ["tools/tools.lock.json"],
       "groupName": "multitool managed tools",
       "postUpgradeTasks": {
-        "commands": ["multitool --lockfile tools/tools.lock.json update"],
+        "commands": ["bazel run @multitool//tools/multitool:cwd -- --lockfile tools/tools.lock.json update"],
         "fileFilters": ["tools/tools.lock.json"],
         "executionMode": "branch"
       }


### PR DESCRIPTION
## Summary
- Replaced direct `multitool` CLI invocation with `bazel run @multitool//tools/multitool:cwd` in Renovate's post-upgrade task
- Uses the `:cwd` wrapper to ensure the binary runs from the workspace root, so `tools/tools.lock.json` resolves correctly

## Test plan
- [x] Verified `bazel run @multitool//tools/multitool:cwd -- --lockfile tools/tools.lock.json update` runs successfully locally