### PR TITLE
feat: replace renovate multitool manager with hourly GitHub workflow

### DIFF
--- a/.github/workflows/update-multitool.yml
+++ b/.github/workflows/update-multitool.yml
@@ -1,0 +1,26 @@
+name: Update Multitool
+permissions:
+  contents: write
+  pull-requests: write
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch:
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: bazel-contrib/setup-bazel@d68576867819dfdec2cf9586a68795f81461da3e
+        with:
+          bazelisk-cache: true
+      - name: Update multitool lockfile
+        run: bazel run @multitool//tools/multitool:cwd -- --lockfile tools/tools.lock.json update
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b31e2c788f8122c6d27f
+        with:
+          commit-message: "chore(deps): update multitool managed tools"
+          title: "chore(deps): update multitool managed tools"
+          body: Automated update of tools managed by multitool.
+          branch: automated/update-multitool
+          labels: dependencies

--- a/renovate.json
+++ b/renovate.json
@@ -1,24 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", ":approveMajorUpdates", ":automergeAll"],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "fileMatch": ["^tools/tools\\.lock\\.json$"],
-      "matchStrings": [
-        "\"url\":\\s*\"https://github\\.com/(?<depName>[^/]+/[^/]+)/releases/download/v(?<currentValue>[^/]+)/[^\"]*\""
-      ],
-      "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "fileMatch": ["^tools/tools\\.lock\\.json$"],
-      "matchStrings": [
-        "\"url\":\\s*\"https://releases\\.hashicorp\\.com/(?<depName>[^/]+)/(?<currentValue>[^/]+)/[^\"]*\""
-      ],
-      "datasourceTemplate": "hashicorp"
-    }
-  ],
   "packageRules": [
     {
       "matchManagers": ["bazel-module"],
@@ -35,15 +17,6 @@
         "commands": ["bazel mod deps --lockfile_mode=update"],
         "fileFilters": ["MODULE.bazel.lock"],
         "executionMode": "update"
-      }
-    },
-    {
-      "matchFileNames": ["tools/tools.lock.json"],
-      "groupName": "multitool managed tools",
-      "postUpgradeTasks": {
-        "commands": ["bazel run @multitool//tools/multitool:cwd -- --lockfile tools/tools.lock.json update"],
-        "fileFilters": ["tools/tools.lock.json"],
-        "executionMode": "branch"
       }
     }
   ],


### PR DESCRIPTION
## Summary
- Removed custom Renovate regex managers and package rule for multitool lockfile updates
- Added a new GitHub Actions workflow (`update-multitool.yml`) that runs hourly and on manual dispatch
- The workflow runs `bazel run @multitool//tools/multitool:cwd -- --lockfile tools/tools.lock.json update` and opens a PR via `peter-evans/create-pull-request` if changes are detected