### PR TITLE
build: enable renovate nix manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", ":approveMajorUpdates", ":automergeAll"],
+  "nix": {
+    "enabled": true
+  },
   "packageRules": [
     {
       "matchManagers": ["bazel-module"],


### PR DESCRIPTION
## Summary
- Enables Renovate's [`nix` manager](https://docs.renovatebot.com/modules/manager/nix/), which is disabled by default, so flake inputs in `flake.nix` (currently `nixpkgs`) are tracked and updated by Renovate.