### PR TITLE
refactor: Migrate Angular app tests to Vitest

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,13 +31,6 @@ jobs:
         run: sudo apt-get install -y lcov
       - name: Run Coverage (remote)
         run: bazel run //tools/coverage -- //... --config=ci-remote
-      - name: Run Coverage (local-only tests)
-        run: |
-          bazel coverage //... --test_tag_filters=no-remote
-          LOCAL_DAT="$(bazel info output_path)/_coverage/_coverage_report.dat"
-          if [[ -f "$LOCAL_DAT" ]] && lcov --summary "$LOCAL_DAT" &>/dev/null; then
-            lcov --add-tracefile coverage-report.lcov --add-tracefile "$LOCAL_DAT" --output-file coverage-report.lcov
-          fi
       - name: Upload to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -44,6 +44,3 @@ jobs:
       - name: Run Bazel tests (remote)
         run: |
           bazel test //... --config=ci-remote
-      - name: Run Bazel tests (local-only)
-        run: |
-          bazel test //... --test_tag_filters=no-remote

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 rbe-image/bookworm.lock.json
 MODULE.bazel.lock
 maven_install.json
+flake.lock

--- a/angular/angular.json
+++ b/angular/angular.json
@@ -63,19 +63,12 @@
           "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular/build:karma",
+          "builder": "@angular/build:unit-test",
           "options": {
-            "codeCoverage": true,
-            "karmaConfig": "karma-bazel.conf.js",
             "tsConfig": "projects/nicknamer/tsconfig.spec.json",
-            "browsers": "ChromeHeadlessNoSandbox",
-            "assets": [
-              {
-                "glob": "**/*",
-                "input": "projects/nicknamer/public"
-              }
-            ],
-            "styles": ["projects/nicknamer/src/styles.css"]
+            "coverage": true,
+            "coverageReporters": ["lcovonly"],
+            "runnerConfig": "projects/nicknamer/vitest-base.config.ts"
           }
         }
       }
@@ -140,19 +133,12 @@
           "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular/build:karma",
+          "builder": "@angular/build:unit-test",
           "options": {
-            "codeCoverage": true,
-            "karmaConfig": "karma-bazel.conf.js",
             "tsConfig": "projects/tailwind-sample/tsconfig.spec.json",
-            "browsers": "ChromeHeadlessNoSandbox",
-            "assets": [
-              {
-                "glob": "**/*",
-                "input": "projects/tailwind-sample/public"
-              }
-            ],
-            "styles": ["projects/tailwind-sample/src/processed_styles.css"]
+            "coverage": true,
+            "coverageReporters": ["lcovonly"],
+            "runnerConfig": "projects/tailwind-sample/vitest-base.config.ts"
           }
         }
       }
@@ -225,20 +211,12 @@
           "builder": "@angular/build:extract-i18n"
         },
         "test": {
-          "builder": "@angular/build:karma",
+          "builder": "@angular/build:unit-test",
           "options": {
-            "codeCoverage": true,
-            "karmaConfig": "karma-bazel.conf.js",
-            "browsers": "ChromeHeadlessNoSandbox",
-            "polyfills": ["zone.js", "zone.js/testing"],
             "tsConfig": "projects/mindreadr/tsconfig.spec.json",
-            "assets": [
-              {
-                "glob": "**/*",
-                "input": "projects/mindreadr/public"
-              }
-            ],
-            "styles": ["projects/mindreadr/src/processed_styles.css"]
+            "coverage": true,
+            "coverageReporters": ["lcovonly"],
+            "runnerConfig": "projects/mindreadr/vitest-base.config.ts"
           }
         }
       }
@@ -306,19 +284,12 @@
           "defaultConfiguration": "development"
         },
         "test": {
-          "builder": "@angular/build:karma",
+          "builder": "@angular/build:unit-test",
           "options": {
-            "codeCoverage": true,
-            "karmaConfig": "karma-bazel.conf.js",
-            "browsers": "ChromeHeadlessNoSandbox",
             "tsConfig": "projects/predix/tsconfig.spec.json",
-            "assets": [
-              {
-                "glob": "**/*",
-                "input": "projects/predix/public"
-              }
-            ],
-            "styles": ["projects/predix/src/processed_styles.css"]
+            "coverage": true,
+            "coverageReporters": ["lcovonly"],
+            "runnerConfig": "projects/predix/vitest-base.config.ts"
           }
         }
       }

--- a/angular/projects/mindreadr/BUILD.bazel
+++ b/angular/projects/mindreadr/BUILD.bazel
@@ -17,6 +17,14 @@ copy_to_bin(
     ),
 )
 
+copy_to_bin(
+    name = "vitest_config_files",
+    srcs = [
+        "vitest-base.config.ts",
+        "vitest-global-setup.ts",
+    ],
+)
+
 process_styles(
     name = "processed_styles",
     src = "src/styles.css",
@@ -57,9 +65,10 @@ ng_test(
     srcs = [
         ":processed_styles",
         ":srcs",
+        ":vitest_config_files",
     ],
-    karma = True,
     tailwindcss = True,
+    vitest = True,
     zonejs = True,
     deps = [
         ":canvas_confetti",

--- a/angular/projects/mindreadr/src/app/game-summary/game-summary.component.spec.ts
+++ b/angular/projects/mindreadr/src/app/game-summary/game-summary.component.spec.ts
@@ -1,15 +1,24 @@
-import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import { vi } from 'vitest';
 import { ActivatedRoute, Router } from '@angular/router';
+
+vi.mock('canvas-confetti', () => ({
+  default: vi.fn(),
+}));
 import { GameSummaryComponent } from './game-summary.component';
 import { GameDto } from '../services/game.types';
 
 describe('GameSummaryComponent', () => {
   const TEST_ANIMATION_DELAY = 50; // Use faster delay for tests
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   function createComponentWithNavState(state: any, id: string | null = 'g1') {
     const routerSpy = {
       currentNavigation: () => ({ extras: { state } }),
-      navigate: jasmine.createSpy('navigate'),
+      navigate: vi.fn(),
     } as any as Router;
     TestBed.configureTestingModule({
       imports: [GameSummaryComponent],
@@ -49,16 +58,16 @@ describe('GameSummaryComponent', () => {
     expect(comp.guessedWord()).toBe('Sunflower');
   });
 
-  it('shows inline error and redirects when finalGame is missing', (done) => {
+  it('shows inline error and redirects when finalGame is missing', async () => {
+    vi.useFakeTimers();
     const { comp, routerSpy } = createComponentWithNavState({}, 'g1');
     expect(comp.error()).toContain('Summary unavailable');
-    setTimeout(() => {
-      expect(routerSpy.navigate).toHaveBeenCalledWith(['/games']);
-      done();
-    }, 1600);
+    await vi.advanceTimersByTimeAsync(1600);
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/games']);
   });
 
-  it('orders rounds ascending by round number', fakeAsync(() => {
+  it('orders rounds ascending by round number', async () => {
+    vi.useFakeTimers();
     const finalGame: GameDto = {
       id: 'g2',
       playerLimit: 2,
@@ -75,8 +84,7 @@ describe('GameSummaryComponent', () => {
       finalGame,
     });
 
-    // Wait for animation delays (2 rounds * delay)
-    tick(2 * TEST_ANIMATION_DELAY);
+    await vi.advanceTimersByTimeAsync(2 * TEST_ANIMATION_DELAY);
     fixture.detectChanges();
 
     const el: HTMLElement = fixture.nativeElement as HTMLElement;
@@ -84,9 +92,10 @@ describe('GameSummaryComponent', () => {
     expect(roundHeaders.length).toBe(2);
     expect(roundHeaders[0].textContent?.trim()).toContain('Round #1');
     expect(roundHeaders[1].textContent?.trim()).toContain('Round #2');
-  }));
+  });
 
-  it('orders player names alphabetically in guesses', fakeAsync(() => {
+  it('orders player names alphabetically in guesses', async () => {
+    vi.useFakeTimers();
     const finalGame: GameDto = {
       id: 'g3',
       playerLimit: 2,
@@ -100,8 +109,7 @@ describe('GameSummaryComponent', () => {
       finalGame,
     });
 
-    // Wait for animation delay (1 round * delay)
-    tick(TEST_ANIMATION_DELAY);
+    await vi.advanceTimersByTimeAsync(TEST_ANIMATION_DELAY);
     fixture.detectChanges();
 
     const el: HTMLElement = fixture.nativeElement as HTMLElement;
@@ -109,5 +117,5 @@ describe('GameSummaryComponent', () => {
       el.querySelectorAll('div.font-semibold'),
     ).map((n) => (n.textContent || '').replace(':', '').trim());
     expect(guessLabels).toEqual(['Alice', 'Bob']);
-  }));
+  });
 });

--- a/angular/projects/mindreadr/src/app/game-timeout/game-timeout.component.spec.ts
+++ b/angular/projects/mindreadr/src/app/game-timeout/game-timeout.component.spec.ts
@@ -1,4 +1,5 @@
-import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import { vi } from 'vitest';
 import { ActivatedRoute, Router } from '@angular/router';
 import { GameTimeoutComponent } from './game-timeout.component';
 import { GameDto } from '../services/game.types';
@@ -6,10 +7,14 @@ import { GameDto } from '../services/game.types';
 describe('GameTimeoutComponent', () => {
   const TEST_ANIMATION_DELAY = 50; // Use faster delay for tests
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   function createComponentWithNavState(state: any, id: string | null = 'g1') {
     const routerSpy = {
       currentNavigation: () => ({ extras: { state } }),
-      navigate: jasmine.createSpy('navigate'),
+      navigate: vi.fn(),
     } as any as Router;
     TestBed.configureTestingModule({
       imports: [GameTimeoutComponent],
@@ -49,16 +54,16 @@ describe('GameTimeoutComponent', () => {
     expect(comp.game()).toEqual(finalGame);
   });
 
-  it('shows inline error and redirects when finalGame is missing', (done) => {
+  it('shows inline error and redirects when finalGame is missing', async () => {
+    vi.useFakeTimers();
     const { comp, routerSpy } = createComponentWithNavState({}, 'g1');
     expect(comp.error()).toContain('Game data unavailable');
-    setTimeout(() => {
-      expect(routerSpy.navigate).toHaveBeenCalledWith(['/games']);
-      done();
-    }, 1600);
+    await vi.advanceTimersByTimeAsync(1600);
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/games']);
   });
 
-  it('orders rounds ascending by round number', fakeAsync(() => {
+  it('orders rounds ascending by round number', async () => {
+    vi.useFakeTimers();
     const finalGame: GameDto = {
       id: 'g2',
       playerLimit: 2,
@@ -76,8 +81,7 @@ describe('GameTimeoutComponent', () => {
       finalGame,
     });
 
-    // Wait for animation delays (3 rounds * delay)
-    tick(3 * TEST_ANIMATION_DELAY);
+    await vi.advanceTimersByTimeAsync(3 * TEST_ANIMATION_DELAY);
     fixture.detectChanges();
 
     const el: HTMLElement = fixture.nativeElement as HTMLElement;
@@ -86,9 +90,10 @@ describe('GameTimeoutComponent', () => {
     expect(roundHeaders[0].textContent?.trim()).toContain('Round #1');
     expect(roundHeaders[1].textContent?.trim()).toContain('Round #2');
     expect(roundHeaders[2].textContent?.trim()).toContain('Round #3');
-  }));
+  });
 
-  it('orders player names alphabetically in guesses', fakeAsync(() => {
+  it('orders player names alphabetically in guesses', async () => {
+    vi.useFakeTimers();
     const finalGame: GameDto = {
       id: 'g3',
       playerLimit: 2,
@@ -102,8 +107,7 @@ describe('GameTimeoutComponent', () => {
       finalGame,
     });
 
-    // Wait for animation delay (1 round * delay)
-    tick(TEST_ANIMATION_DELAY);
+    await vi.advanceTimersByTimeAsync(TEST_ANIMATION_DELAY);
     fixture.detectChanges();
 
     const el: HTMLElement = fixture.nativeElement as HTMLElement;
@@ -111,9 +115,10 @@ describe('GameTimeoutComponent', () => {
       el.querySelectorAll('div.font-semibold'),
     ).map((n) => (n.textContent || '').replace(':', '').trim());
     expect(guessLabels).toEqual(['Alice', 'Bob']);
-  }));
+  });
 
-  it('shows all rounds when game times out', fakeAsync(() => {
+  it('shows all rounds when game times out', async () => {
+    vi.useFakeTimers();
     const finalGame: GameDto = {
       id: 'g4',
       playerLimit: 2,
@@ -131,8 +136,7 @@ describe('GameTimeoutComponent', () => {
       finalGame,
     });
 
-    // Wait for animation delays (3 rounds * delay)
-    tick(3 * TEST_ANIMATION_DELAY);
+    await vi.advanceTimersByTimeAsync(3 * TEST_ANIMATION_DELAY);
     fixture.detectChanges();
 
     expect(comp.roundsCount()).toBe(3);
@@ -142,5 +146,5 @@ describe('GameTimeoutComponent', () => {
     expect(roundHeaders.length).toBe(3);
     expect(roundHeaders[0].textContent?.trim()).toContain('Round #1');
     expect(roundHeaders[2].textContent?.trim()).toContain('Round #3');
-  }));
+  });
 });

--- a/angular/projects/mindreadr/src/app/games-count/games-count.component.spec.ts
+++ b/angular/projects/mindreadr/src/app/games-count/games-count.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { vi } from 'vitest';
 import { GamesCountComponent } from './games-count.component';
 import { GameService } from '../services/game.service';
 import { of, throwError } from 'rxjs';
@@ -6,9 +7,9 @@ import { Component } from '@angular/core';
 
 // Mock GameService
 class MockGameService {
-  getSummary = jasmine
-    .createSpy()
-    .and.returnValue(
+  getSummary = vi
+    .fn()
+    .mockReturnValue(
       of({ inProgressGames: 5, waitingForPlayerGames: 3, completedGames: 2 }),
     );
 }
@@ -51,7 +52,7 @@ describe('GamesCountComponent', () => {
   });
 
   it('should handle errors from either service', () => {
-    gameService.getSummary.and.returnValue(
+    gameService.getSummary.mockReturnValue(
       throwError(() => ({ message: 'fail' })),
     );
     component.fetchCounts();

--- a/angular/projects/mindreadr/src/app/games/games.component.spec.ts
+++ b/angular/projects/mindreadr/src/app/games/games.component.spec.ts
@@ -1,11 +1,6 @@
-import {
-  ComponentFixture,
-  TestBed,
-  fakeAsync,
-  tick,
-  discardPeriodicTasks,
-} from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { GamesComponent } from './games.component';
+import { vi } from 'vitest';
 import { GameService } from '../services/game.service';
 import { GameDto } from '../services/game.types';
 import { Component } from '@angular/core';
@@ -14,12 +9,8 @@ import { Router } from '@angular/router';
 
 // Mock GameService with spies
 class MockGameService {
-  createGame = jasmine
-    .createSpy()
-    .and.returnValue(of({ id: 'new-game' } as GameDto));
-  getGamesByStatus = jasmine
-    .createSpy()
-    .and.returnValue(of([{ id: 'g1' } as GameDto]));
+  createGame = vi.fn().mockReturnValue(of({ id: 'new-game' } as GameDto));
+  getGamesByStatus = vi.fn().mockReturnValue(of([{ id: 'g1' } as GameDto]));
 }
 
 // Optional host for template mounting scenarios
@@ -42,7 +33,7 @@ describe('GamesComponent', () => {
         { provide: GameService, useClass: MockGameService },
         {
           provide: Router,
-          useValue: { navigate: jasmine.createSpy('navigate') },
+          useValue: { navigate: vi.fn() },
         },
       ],
     }).compileComponents();
@@ -57,23 +48,23 @@ describe('GamesComponent', () => {
   });
 
   it('fetches waiting games on init and sets state', () => {
-    gameService.getGamesByStatus.and.returnValue(of([{ id: 'a' } as GameDto]));
+    gameService.getGamesByStatus.mockReturnValue(of([{ id: 'a' } as GameDto]));
     fixture.detectChanges();
     expect(gameService.getGamesByStatus).toHaveBeenCalledWith(
       'WAITING_FOR_PLAYERS',
     );
     expect(component.games().length).toBe(1);
-    expect(component.loading()).toBeFalse();
+    expect(component.loading()).toBe(false);
     expect(component.error()).toBeNull();
   });
 
   it('handles error when fetching games', () => {
-    gameService.getGamesByStatus.and.returnValue(
+    gameService.getGamesByStatus.mockReturnValue(
       throwError(() => new Error('boom')),
     );
     component.fetchWaitingGames();
     expect(component.error()).toBe('Failed to load games');
-    expect(component.loading()).toBeFalse();
+    expect(component.loading()).toBe(false);
   });
 
   it('shows spinner while loading', () => {
@@ -89,7 +80,7 @@ describe('GamesComponent', () => {
 
   it('renders list items when games exist', () => {
     // Prevent ngOnInit fetch from overwriting our state
-    gameService.getGamesByStatus.and.returnValue(of([]));
+    gameService.getGamesByStatus.mockReturnValue(of([]));
     fixture.detectChanges();
     component.loading.set(false);
     component.games.set([{ id: '1' } as GameDto, { id: '2' } as GameDto]);
@@ -110,16 +101,19 @@ describe('GamesComponent', () => {
       b.textContent?.includes('Create Game'),
     ) as HTMLButtonElement;
     expect(createBtn).toBeTruthy();
-    expect(createBtn.disabled).toBeTrue();
+    expect(createBtn.disabled).toBe(true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('calls createGame and refreshes list on createNewGame()', () => {
-    // Avoid ngOnInit interference: reset spies for clarity
-    gameService.getGamesByStatus.calls.reset();
-    gameService.createGame.calls.reset();
+    gameService.getGamesByStatus.mockClear();
+    gameService.createGame.mockClear();
 
-    gameService.createGame.and.returnValue(of({ id: 'created' } as GameDto));
-    gameService.getGamesByStatus.and.returnValue(
+    gameService.createGame.mockReturnValue(of({ id: 'created' } as GameDto));
+    gameService.getGamesByStatus.mockReturnValue(
       of([{ id: 'created' } as GameDto]),
     );
 
@@ -129,7 +123,7 @@ describe('GamesComponent', () => {
     expect(gameService.getGamesByStatus).toHaveBeenCalledWith(
       'WAITING_FOR_PLAYERS',
     );
-    expect(component.loading()).toBeFalse();
+    expect(component.loading()).toBe(false);
     expect(component.games().length).toBe(1);
   });
 
@@ -139,88 +133,74 @@ describe('GamesComponent', () => {
     expect(router.navigate).toHaveBeenCalledWith(['/games', '123', 'live']);
   });
 
-  it('starts polling for games every 1 second after init', fakeAsync(() => {
-    gameService.getGamesByStatus.calls.reset();
-    gameService.getGamesByStatus.and.returnValue(
+  it('starts polling for games every 1 second after init', async () => {
+    vi.useFakeTimers();
+    gameService.getGamesByStatus.mockClear();
+    gameService.getGamesByStatus.mockReturnValue(
       of([{ id: 'game1' } as GameDto]),
     );
 
-    fixture.detectChanges(); // triggers ngOnInit
-
-    // Initial fetch happens immediately
+    fixture.detectChanges();
     expect(gameService.getGamesByStatus).toHaveBeenCalledTimes(1);
 
-    // After 1 second, polling should trigger another fetch
-    tick(1000);
+    await vi.advanceTimersByTimeAsync(1000);
     expect(gameService.getGamesByStatus).toHaveBeenCalledTimes(2);
 
-    // After another second, another fetch
-    tick(1000);
+    await vi.advanceTimersByTimeAsync(1000);
     expect(gameService.getGamesByStatus).toHaveBeenCalledTimes(3);
+  });
 
-    discardPeriodicTasks();
-  }));
-
-  it('stops polling when component is destroyed', fakeAsync(() => {
-    gameService.getGamesByStatus.calls.reset();
-    gameService.getGamesByStatus.and.returnValue(
+  it('stops polling when component is destroyed', async () => {
+    vi.useFakeTimers();
+    gameService.getGamesByStatus.mockClear();
+    gameService.getGamesByStatus.mockReturnValue(
       of([{ id: 'game1' } as GameDto]),
     );
 
-    fixture.detectChanges(); // triggers ngOnInit
+    fixture.detectChanges();
 
-    // Initial fetch + first poll
-    tick(1000);
+    await vi.advanceTimersByTimeAsync(1000);
     expect(gameService.getGamesByStatus).toHaveBeenCalledTimes(2);
 
-    // Destroy the component
     component.ngOnDestroy();
 
-    // After another second, no more fetches should occur
-    tick(1000);
+    await vi.advanceTimersByTimeAsync(1000);
     expect(gameService.getGamesByStatus).toHaveBeenCalledTimes(2);
+  });
 
-    discardPeriodicTasks();
-  }));
-
-  it('updates games list when polling returns new data', fakeAsync(() => {
-    gameService.getGamesByStatus.and.returnValue(
+  it('updates games list when polling returns new data', async () => {
+    vi.useFakeTimers();
+    gameService.getGamesByStatus.mockReturnValue(
       of([{ id: 'initial' } as GameDto]),
     );
-    fixture.detectChanges(); // triggers ngOnInit
+    fixture.detectChanges();
     expect(component.games().length).toBe(1);
     expect(component.games()[0].id).toBe('initial');
 
-    // Simulate new game appearing
-    gameService.getGamesByStatus.and.returnValue(
+    gameService.getGamesByStatus.mockReturnValue(
       of([{ id: 'initial' } as GameDto, { id: 'new' } as GameDto]),
     );
-    tick(1000);
+    await vi.advanceTimersByTimeAsync(1000);
 
     expect(component.games().length).toBe(2);
     expect(component.games()[1].id).toBe('new');
+  });
 
-    discardPeriodicTasks();
-  }));
-
-  it('silently handles polling errors without affecting displayed games', fakeAsync(() => {
-    gameService.getGamesByStatus.and.returnValue(
+  it('silently handles polling errors without affecting displayed games', async () => {
+    vi.useFakeTimers();
+    gameService.getGamesByStatus.mockReturnValue(
       of([{ id: 'game1' } as GameDto]),
     );
     fixture.detectChanges();
     expect(component.games().length).toBe(1);
     expect(component.error()).toBeNull();
 
-    // Make the next poll fail
-    gameService.getGamesByStatus.and.returnValue(
+    gameService.getGamesByStatus.mockReturnValue(
       throwError(() => new Error('network error')),
     );
-    tick(1000);
+    await vi.advanceTimersByTimeAsync(1000);
 
-    // Games should still be displayed (no error shown for polling failures)
     expect(component.games().length).toBe(1);
     expect(component.error()).toBeNull();
-
-    discardPeriodicTasks();
-  }));
+  });
 });

--- a/angular/projects/mindreadr/src/app/landing/landing.component.spec.ts
+++ b/angular/projects/mindreadr/src/app/landing/landing.component.spec.ts
@@ -1,11 +1,5 @@
-import {
-  ComponentFixture,
-  TestBed,
-  fakeAsync,
-  tick,
-  discardPeriodicTasks,
-} from '@angular/core/testing';
-import { Router } from '@angular/router';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { vi } from 'vitest';
 import { Location } from '@angular/common';
 import { LandingComponent } from './landing.component';
 import { GameService } from '../services/game.service';
@@ -17,9 +11,9 @@ import { provideHttpClientTesting } from '@angular/common/http/testing';
 
 // Mock GameService
 class MockGameService {
-  getSummary = jasmine
-    .createSpy()
-    .and.returnValue(
+  getSummary = vi
+    .fn()
+    .mockReturnValue(
       of({ inProgressGames: 0, waitingForPlayerGames: 0, completedGames: 0 }),
     );
 }
@@ -27,7 +21,6 @@ class MockGameService {
 describe('LandingComponent', () => {
   let component: LandingComponent;
   let fixture: ComponentFixture<LandingComponent>;
-  let router: Router;
   let location: Location;
 
   beforeEach(async () => {
@@ -43,7 +36,6 @@ describe('LandingComponent', () => {
 
     fixture = TestBed.createComponent(LandingComponent);
     component = fixture.componentInstance;
-    router = TestBed.inject(Router);
     location = TestBed.inject(Location);
     fixture.detectChanges();
   });
@@ -65,21 +57,18 @@ describe('LandingComponent', () => {
     expect(button).toBeTruthy();
   });
 
-  it('should navigate to /games when Browse Games button is clicked', fakeAsync(() => {
+  it('should navigate to /games when Browse Games button is clicked', async () => {
     const compiled = fixture.nativeElement as HTMLElement;
     const button = compiled.querySelector(
       'button.btn-primary',
     ) as HTMLButtonElement;
     expect(button).toBeTruthy();
 
-    // Click the button
     button.click();
-    tick(0);
+    await fixture.whenStable();
 
-    // Verify navigation occurred
     expect(location.path()).toBe('/games');
-    discardPeriodicTasks();
-  }));
+  });
 
   it('should display the component title', () => {
     const compiled = fixture.nativeElement as HTMLElement;

--- a/angular/projects/mindreadr/src/app/live-game/live-game.component.spec.ts
+++ b/angular/projects/mindreadr/src/app/live-game/live-game.component.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { vi } from 'vitest';
 import { LiveGameComponent } from './live-game.component';
 import { ActivatedRoute, Router } from '@angular/router';
 import { GameWsService } from '../services/game-ws.service';
@@ -19,7 +20,7 @@ describe('LiveGameComponent logic', () => {
         { provide: GameWsService, useValue: {} },
         {
           provide: Router,
-          useValue: { navigate: jasmine.createSpy('navigate') },
+          useValue: { navigate: vi.fn() },
         },
       ],
     });
@@ -49,8 +50,8 @@ describe('LiveGameComponent logic', () => {
     component.game.set(game);
     component.currentPlayer.set(p1);
 
-    expect(component.shouldHideGuesses(round, game)).toBeTrue();
-    expect(component.waitingForOtherPlayer()).toBeTrue();
+    expect(component.shouldHideGuesses(round, game)).toBe(true);
+    expect(component.waitingForOtherPlayer()).toBe(true);
   });
 
   it('reveals guesses and not waiting when all players have guessed', () => {
@@ -71,8 +72,8 @@ describe('LiveGameComponent logic', () => {
     component.game.set(game);
     component.currentPlayer.set(p1);
 
-    expect(component.shouldHideGuesses(round, game)).toBeFalse();
-    expect(component.waitingForOtherPlayer()).toBeFalse();
+    expect(component.shouldHideGuesses(round, game)).toBe(false);
+    expect(component.waitingForOtherPlayer()).toBe(false);
   });
 
   it('detects player guess via id fallback when name key missing', () => {
@@ -94,8 +95,8 @@ describe('LiveGameComponent logic', () => {
     component.currentPlayer.set(p1);
 
     // All guessed -> not hidden
-    expect(component.shouldHideGuesses(round, game)).toBeFalse();
-    expect(component.waitingForOtherPlayer()).toBeFalse();
+    expect(component.shouldHideGuesses(round, game)).toBe(false);
+    expect(component.waitingForOtherPlayer()).toBe(false);
   });
 
   it('returns empty array for reversedRounds when game is null', () => {
@@ -202,8 +203,8 @@ describe('LiveGameComponent navigation', () => {
       terminated$,
       playerJoined$,
       playerLeft$,
-      submitGuess: jasmine.createSpy('submitGuess'),
-      close: jasmine.createSpy('close'),
+      submitGuess: vi.fn(),
+      close: vi.fn(),
     };
 
     TestBed.configureTestingModule({
@@ -216,7 +217,7 @@ describe('LiveGameComponent navigation', () => {
         { provide: GameWsService, useValue: { connect: () => mockConn } },
         {
           provide: Router,
-          useValue: { navigate: jasmine.createSpy('navigate') },
+          useValue: { navigate: vi.fn() },
         },
       ],
     });
@@ -238,7 +239,7 @@ describe('LiveGameComponent navigation', () => {
     };
     gameState$.next(game);
     expect(router.navigate).toHaveBeenCalledWith(['/games/g1/summary'], {
-      state: jasmine.objectContaining({
+      state: expect.objectContaining({
         playerName: 'Player',
         finalGame: game,
       }),
@@ -248,7 +249,7 @@ describe('LiveGameComponent navigation', () => {
   it('navigates to summary when terminated with COMPLETED', () => {
     terminated$.next('COMPLETED');
     expect(router.navigate).toHaveBeenCalledWith(['/games/g1/summary'], {
-      state: jasmine.objectContaining({ playerName: 'Player' }),
+      state: expect.objectContaining({ playerName: 'Player' }),
     });
   });
 
@@ -266,7 +267,7 @@ describe('LiveGameComponent navigation', () => {
     };
     gameState$.next(game);
     expect(router.navigate).toHaveBeenCalledWith(['/games/g1/timeout'], {
-      state: jasmine.objectContaining({
+      state: expect.objectContaining({
         playerName: 'Player',
         finalGame: game,
       }),
@@ -302,7 +303,7 @@ describe('LiveGameComponent navigation', () => {
     component.game.set(game);
     terminated$.next('TERMINATED');
     expect(router.navigate).toHaveBeenCalledWith(['/games/g1/timeout'], {
-      state: jasmine.objectContaining({ playerName: 'Player' }),
+      state: expect.objectContaining({ playerName: 'Player' }),
     });
   });
 

--- a/angular/projects/mindreadr/src/app/services/game-ws.service.spec.ts
+++ b/angular/projects/mindreadr/src/app/services/game-ws.service.spec.ts
@@ -1,4 +1,5 @@
 import { GameWsService, ServerMessage } from './game-ws.service';
+import { vi } from 'vitest';
 import { Subject, firstValueFrom, take } from 'rxjs';
 
 // Allow mutating API_BASE_URL during tests
@@ -40,10 +41,12 @@ describe('GameWsService', () => {
     };
 
     capturedUrl = undefined;
-    spyOn<any>(service as any, 'createSocket').and.callFake((config: any) => {
-      capturedUrl = config?.url;
-      return fake as any;
-    });
+    vi.spyOn(service as never, 'createSocket' as never).mockImplementation(
+      (config: { url?: string }) => {
+        capturedUrl = config?.url;
+        return fake as never;
+      },
+    );
   });
 
   it('builds a ws URL and encodes gameId', () => {
@@ -90,13 +93,13 @@ describe('GameWsService', () => {
 
     // Termination is covered by a dedicated test to avoid race conditions
 
-    await expectAsync(gameStateP).toBeResolvedTo(
-      jasmine.objectContaining({ id: 'g1' }),
+    await expect(gameStateP).resolves.toEqual(
+      expect.objectContaining({ id: 'g1' }),
     );
-    await expectAsync(playerJoinedP).toBeResolvedTo(
-      jasmine.objectContaining({ name: 'Alice' }),
+    await expect(playerJoinedP).resolves.toEqual(
+      expect.objectContaining({ name: 'Alice' }),
     );
-    await expectAsync(errorP).toBeResolvedTo('nope');
+    await expect(errorP).resolves.toBe('nope');
   });
 
   it('submitGuess sends the correct payload', () => {
@@ -105,7 +108,7 @@ describe('GameWsService', () => {
 
     conn.submitGuess('word');
     expect(fake.sent).toEqual(
-      jasmine.arrayContaining([{ type: 'submit_guess', guess: 'word' }]),
+      expect.arrayContaining([{ type: 'submit_guess', guess: 'word' }]),
     );
   });
 
@@ -114,7 +117,7 @@ describe('GameWsService', () => {
     const conn = service.connect('game');
     const termP = firstValueFrom(conn.terminated$);
 
-    expect(fake.completed).toBeFalse();
+    expect(fake.completed).toBe(false);
     // Emulate server sending a completed game state
     fake.incoming$.next({
       type: 'game_state',
@@ -129,9 +132,9 @@ describe('GameWsService', () => {
       },
     } as ServerMessage);
 
-    await expectAsync(termP).toBeResolvedTo('COMPLETED');
+    await expect(termP).resolves.toBe('COMPLETED');
     // Auto-close should have completed the fake socket
-    expect(fake.completed).toBeTrue();
+    expect(fake.completed).toBe(true);
   });
 
   it('auto-closes and emits TERMINATED state', async () => {
@@ -152,8 +155,8 @@ describe('GameWsService', () => {
       },
     } as ServerMessage);
 
-    await expectAsync(termP).toBeResolvedTo('TERMINATED');
-    expect(fake.completed).toBeTrue();
+    await expect(termP).resolves.toBe('TERMINATED');
+    expect(fake.completed).toBe(true);
   });
 
   it('stops forwarding messages after close()', async () => {

--- a/angular/projects/mindreadr/src/app/services/game.service.spec.ts
+++ b/angular/projects/mindreadr/src/app/services/game.service.spec.ts
@@ -3,6 +3,7 @@ import {
   HttpTestingController,
   provideHttpClientTesting,
 } from '@angular/common/http/testing';
+import { firstValueFrom } from 'rxjs';
 import { GameService, GameSummary } from './game.service';
 import { GameDto } from '../services/game.types';
 import { environment } from '../../environments/environment';
@@ -25,24 +26,22 @@ describe('GameService', () => {
     httpMock.verify();
   });
 
-  it('should fetch summary from /games/summary', (done) => {
+  it('should fetch summary from /games/summary', async () => {
     const mock: GameSummary = {
       waitingForPlayerGames: 2,
       inProgressGames: 3,
       completedGames: 4,
     };
 
-    service.getSummary().subscribe((res) => {
-      expect(res).toEqual(mock);
-      done();
-    });
+    const summaryPromise = firstValueFrom(service.getSummary());
 
     const req = httpMock.expectOne(`${environment.API_BASE_URL}/games/summary`);
     expect(req.request.method).toBe('GET');
     req.flush(mock);
+    await expect(summaryPromise).resolves.toEqual(mock);
   });
 
-  it('getGamesByStatus should fetch /games?status=WAITING_FOR_PLAYERS', (done) => {
+  it('getGamesByStatus should fetch /games?status=WAITING_FOR_PLAYERS', async () => {
     const mockGames: GameDto[] = [
       {
         id: 'G1',
@@ -62,20 +61,19 @@ describe('GameService', () => {
       },
     ];
 
-    service.getGamesByStatus('WAITING_FOR_PLAYERS').subscribe((games) => {
-      expect(games).toEqual(mockGames);
-      expect(games.length).toBe(2);
-      done();
-    });
+    const gamesPromise = firstValueFrom(
+      service.getGamesByStatus('WAITING_FOR_PLAYERS'),
+    );
 
     const req = httpMock.expectOne(
       `${environment.API_BASE_URL}/games?status=WAITING_FOR_PLAYERS`,
     );
     expect(req.request.method).toBe('GET');
     req.flush(mockGames);
+    await expect(gamesPromise).resolves.toEqual(mockGames);
   });
 
-  it('getGamesByStatus should fetch /games?status=IN_PROGRESS', (done) => {
+  it('getGamesByStatus should fetch /games?status=IN_PROGRESS', async () => {
     const mockGames: GameDto[] = [
       {
         id: 'IP1',
@@ -103,20 +101,19 @@ describe('GameService', () => {
       },
     ];
 
-    service.getGamesByStatus('IN_PROGRESS').subscribe((games) => {
-      expect(games).toEqual(mockGames);
-      expect(games.every((g) => g.state === 'IN_PROGRESS')).toBeTrue();
-      done();
-    });
+    const gamesPromise = firstValueFrom(
+      service.getGamesByStatus('IN_PROGRESS'),
+    );
 
     const req = httpMock.expectOne(
       `${environment.API_BASE_URL}/games?status=IN_PROGRESS`,
     );
     expect(req.request.method).toBe('GET');
     req.flush(mockGames);
+    await expect(gamesPromise).resolves.toEqual(mockGames);
   });
 
-  it('getGamesByStatus should fetch /games?status=COMPLETED', (done) => {
+  it('getGamesByStatus should fetch /games?status=COMPLETED', async () => {
     const mockGames: GameDto[] = [
       {
         id: 'C1',
@@ -128,17 +125,13 @@ describe('GameService', () => {
       },
     ];
 
-    service.getGamesByStatus('COMPLETED').subscribe((games) => {
-      expect(games).toEqual(mockGames);
-      expect(games.length).toBe(1);
-      expect(games[0].state).toBe('COMPLETED');
-      done();
-    });
+    const gamesPromise = firstValueFrom(service.getGamesByStatus('COMPLETED'));
 
     const req = httpMock.expectOne(
       `${environment.API_BASE_URL}/games?status=COMPLETED`,
     );
     expect(req.request.method).toBe('GET');
     req.flush(mockGames);
+    await expect(gamesPromise).resolves.toEqual(mockGames);
   });
 });

--- a/angular/projects/mindreadr/tsconfig.spec.json
+++ b/angular/projects/mindreadr/tsconfig.spec.json
@@ -1,10 +1,8 @@
-/* To learn more about Typescript configuration file: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html. */
-/* To learn more about Angular compiler options: https://angular.dev/reference/configs/angular-compiler-options. */
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "../../out-tsc/spec",
-    "types": ["jasmine"]
+    "types": ["vitest/globals"]
   },
   "include": ["src/**/*.d.ts", "src/**/*.spec.ts"]
 }

--- a/angular/projects/mindreadr/vitest-base.config.ts
+++ b/angular/projects/mindreadr/vitest-base.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Write coverage to a known location relative to the config file so the
+// globalSetup teardown can reliably find it.
+const reportsDirectory = join(__dirname, '.vitest-coverage');
+
+export default defineConfig({
+  test: {
+    coverage: {
+      reportsDirectory,
+    },
+    // Always wire the global setup — teardown is a no-op when not under
+    // `bazel coverage` (checks COVERAGE_OUTPUT_FILE at runtime).
+    globalSetup: [join(__dirname, 'vitest-global-setup.ts')],
+  },
+});

--- a/angular/projects/mindreadr/vitest-global-setup.ts
+++ b/angular/projects/mindreadr/vitest-global-setup.ts
@@ -1,0 +1,33 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export async function teardown() {
+  const coverageOutputFile = process.env['COVERAGE_OUTPUT_FILE'];
+  // No-op when not running under `bazel coverage`.
+  if (!coverageOutputFile) return;
+
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const lcovSrc = join(__dirname, '.vitest-coverage', 'lcov.info');
+
+  if (!existsSync(lcovSrc)) {
+    process.stderr.write(
+      `[vitest-coverage] lcov file not found at: ${lcovSrc}\n`,
+    );
+    return;
+  }
+
+  // The Angular CLI's vitest runner sets root=workspaceRoot (angular/), so
+  // coverage paths are relative to angular/ rather than the repo root.
+  // Bazel's instrumentation_filter and lcov aggregator expect paths prefixed
+  // with "angular/", so we rewrite SF: lines before emitting.
+  const content = readFileSync(lcovSrc, 'utf-8');
+  const fixed = content.replace(/^(SF:)(?!angular\/)/gm, '$1angular/');
+
+  mkdirSync(dirname(coverageOutputFile), { recursive: true });
+  writeFileSync(coverageOutputFile, fixed, 'utf-8');
+  const sfCount = fixed.split('\n').filter((l) => l.startsWith('SF:')).length;
+  process.stderr.write(
+    `[vitest-coverage] Wrote ${sfCount} SF: entries to: ${coverageOutputFile}\n`,
+  );
+}

--- a/angular/projects/nicknamer/BUILD.bazel
+++ b/angular/projects/nicknamer/BUILD.bazel
@@ -17,6 +17,14 @@ copy_to_bin(
     ),
 )
 
+copy_to_bin(
+    name = "vitest_config_files",
+    srcs = [
+        "vitest-base.config.ts",
+        "vitest-global-setup.ts",
+    ],
+)
+
 ng_application(
     name = "nicknamer",
     srcs = [":srcs"],
@@ -25,7 +33,10 @@ ng_application(
 
 ng_test(
     name = "test",
-    srcs = [":srcs"],
-    karma = True,
+    srcs = [
+        ":srcs",
+        ":vitest_config_files",
+    ],
+    vitest = True,
     zonejs = True,
 )

--- a/angular/projects/nicknamer/tsconfig.spec.json
+++ b/angular/projects/nicknamer/tsconfig.spec.json
@@ -1,10 +1,8 @@
-/* To learn more about Typescript configuration file: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html. */
-/* To learn more about Angular compiler options: https://angular.dev/reference/configs/angular-compiler-options. */
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "../../out-tsc/spec",
-    "types": ["jasmine"]
+    "types": ["vitest/globals"]
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.d.ts", "src/**/*.spec.ts"]
 }

--- a/angular/projects/nicknamer/vitest-base.config.ts
+++ b/angular/projects/nicknamer/vitest-base.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Write coverage to a known location relative to the config file so the
+// globalSetup teardown can reliably find it.
+const reportsDirectory = join(__dirname, '.vitest-coverage');
+
+export default defineConfig({
+  test: {
+    coverage: {
+      reportsDirectory,
+    },
+    // Always wire the global setup — teardown is a no-op when not under
+    // `bazel coverage` (checks COVERAGE_OUTPUT_FILE at runtime).
+    globalSetup: [join(__dirname, 'vitest-global-setup.ts')],
+  },
+});

--- a/angular/projects/nicknamer/vitest-global-setup.ts
+++ b/angular/projects/nicknamer/vitest-global-setup.ts
@@ -1,0 +1,33 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export async function teardown() {
+  const coverageOutputFile = process.env['COVERAGE_OUTPUT_FILE'];
+  // No-op when not running under `bazel coverage`.
+  if (!coverageOutputFile) return;
+
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const lcovSrc = join(__dirname, '.vitest-coverage', 'lcov.info');
+
+  if (!existsSync(lcovSrc)) {
+    process.stderr.write(
+      `[vitest-coverage] lcov file not found at: ${lcovSrc}\n`,
+    );
+    return;
+  }
+
+  // The Angular CLI's vitest runner sets root=workspaceRoot (angular/), so
+  // coverage paths are relative to angular/ rather than the repo root.
+  // Bazel's instrumentation_filter and lcov aggregator expect paths prefixed
+  // with "angular/", so we rewrite SF: lines before emitting.
+  const content = readFileSync(lcovSrc, 'utf-8');
+  const fixed = content.replace(/^(SF:)(?!angular\/)/gm, '$1angular/');
+
+  mkdirSync(dirname(coverageOutputFile), { recursive: true });
+  writeFileSync(coverageOutputFile, fixed, 'utf-8');
+  const sfCount = fixed.split('\n').filter((l) => l.startsWith('SF:')).length;
+  process.stderr.write(
+    `[vitest-coverage] Wrote ${sfCount} SF: entries to: ${coverageOutputFile}\n`,
+  );
+}

--- a/angular/projects/predix/BUILD.bazel
+++ b/angular/projects/predix/BUILD.bazel
@@ -16,6 +16,14 @@ copy_to_bin(
     ),
 )
 
+copy_to_bin(
+    name = "vitest_config_files",
+    srcs = [
+        "vitest-base.config.ts",
+        "vitest-global-setup.ts",
+    ],
+)
+
 process_styles(
     name = "processed_styles",
     src = "src/styles.css",
@@ -47,9 +55,10 @@ ng_test(
     srcs = [
         ":processed_styles",
         ":srcs",
+        ":vitest_config_files",
     ],
-    karma = True,
     tailwindcss = True,
+    vitest = True,
     zonejs = False,
     deps = [
         "//angular:node_modules/daisyui",

--- a/angular/projects/predix/src/app/components/back-button/back-button.component.spec.ts
+++ b/angular/projects/predix/src/app/components/back-button/back-button.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { vi } from 'vitest';
 import { Router } from '@angular/router';
 import { Location } from '@angular/common';
 import { BackButtonComponent } from './back-button.component';
@@ -18,13 +19,13 @@ describe('BackButtonComponent', () => {
         {
           provide: Router,
           useValue: {
-            navigate: jasmine.createSpy('navigate'),
+            navigate: vi.fn(),
           },
         },
         {
           provide: Location,
           useValue: {
-            back: jasmine.createSpy('back'),
+            back: vi.fn(),
           },
         },
       ],

--- a/angular/projects/predix/src/app/components/circle-detail/circle-detail.component.spec.ts
+++ b/angular/projects/predix/src/app/components/circle-detail/circle-detail.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { vi } from 'vitest';
 import { CircleDetailComponent } from './circle-detail.component';
 import { ActivatedRoute, Router } from '@angular/router';
 import { CircleService } from '../../services/circle.service';
@@ -6,12 +7,22 @@ import { DOCUMENT } from '@angular/common';
 import { of, throwError } from 'rxjs';
 import type { Circle } from '../../models/circle.model';
 import type { Contest } from '../../models/contest.model';
+import { createMockObject } from '../../../testing/create-mock-object';
 
 describe('CircleDetailComponent', () => {
+  const circleServiceMethods = [
+    'getCircle',
+    'getCircleContests',
+    'createCircle',
+    'listUserCircles',
+    'addMember',
+    'joinCircle',
+  ] as const;
+  const routerMethods = ['navigate'] as const;
   let component: CircleDetailComponent;
   let fixture: ComponentFixture<CircleDetailComponent>;
-  let mockCircleService: jasmine.SpyObj<CircleService>;
-  let mockRouter: jasmine.SpyObj<Router>;
+  let mockCircleService = createMockObject(circleServiceMethods);
+  let mockRouter = createMockObject(routerMethods);
   let mockActivatedRoute: Partial<ActivatedRoute>;
 
   const mockCircle: Circle = {
@@ -54,19 +65,12 @@ describe('CircleDetailComponent', () => {
   ];
 
   beforeEach(async () => {
-    mockCircleService = jasmine.createSpyObj('CircleService', [
-      'getCircle',
-      'getCircleContests',
-      'createCircle',
-      'listUserCircles',
-      'addMember',
-      'joinCircle',
-    ]);
-    mockRouter = jasmine.createSpyObj('Router', ['navigate']);
+    mockCircleService = createMockObject(circleServiceMethods);
+    mockRouter = createMockObject(routerMethods);
     mockActivatedRoute = {
       snapshot: {
         paramMap: {
-          get: jasmine.createSpy('get').and.returnValue('1'),
+          get: vi.fn().mockReturnValue('1'),
         },
       } as any,
     };
@@ -74,8 +78,11 @@ describe('CircleDetailComponent', () => {
     await TestBed.configureTestingModule({
       imports: [CircleDetailComponent],
       providers: [
-        { provide: CircleService, useValue: mockCircleService },
-        { provide: Router, useValue: mockRouter },
+        {
+          provide: CircleService,
+          useValue: mockCircleService as unknown as CircleService,
+        },
+        { provide: Router, useValue: mockRouter as unknown as Router },
         { provide: ActivatedRoute, useValue: mockActivatedRoute },
         { provide: DOCUMENT, useValue: document },
       ],
@@ -91,8 +98,8 @@ describe('CircleDetailComponent', () => {
 
   describe('ngOnInit', () => {
     it('should load circle and contests on init', () => {
-      mockCircleService.getCircle.and.returnValue(of(mockCircle));
-      mockCircleService.getCircleContests.and.returnValue(of(mockContests));
+      mockCircleService.getCircle.mockReturnValue(of(mockCircle));
+      mockCircleService.getCircleContests.mockReturnValue(of(mockContests));
 
       fixture.detectChanges();
 
@@ -105,10 +112,10 @@ describe('CircleDetailComponent', () => {
     });
 
     it('should handle circle load error', () => {
-      mockCircleService.getCircle.and.returnValue(
+      mockCircleService.getCircle.mockReturnValue(
         throwError(() => new Error('Not found')),
       );
-      mockCircleService.getCircleContests.and.returnValue(of([]));
+      mockCircleService.getCircleContests.mockReturnValue(of([]));
 
       fixture.detectChanges();
 
@@ -117,8 +124,8 @@ describe('CircleDetailComponent', () => {
     });
 
     it('should handle contests load error', () => {
-      mockCircleService.getCircle.and.returnValue(of(mockCircle));
-      mockCircleService.getCircleContests.and.returnValue(
+      mockCircleService.getCircle.mockReturnValue(of(mockCircle));
+      mockCircleService.getCircleContests.mockReturnValue(
         throwError(() => new Error('Server error')),
       );
 
@@ -132,11 +139,11 @@ describe('CircleDetailComponent', () => {
 
   describe('loadContests', () => {
     beforeEach(() => {
-      mockCircleService.getCircle.and.returnValue(of(mockCircle));
+      mockCircleService.getCircle.mockReturnValue(of(mockCircle));
     });
 
     it('should load contests for a circle', () => {
-      mockCircleService.getCircleContests.and.returnValue(of(mockContests));
+      mockCircleService.getCircleContests.mockReturnValue(of(mockContests));
 
       fixture.detectChanges();
 
@@ -145,7 +152,7 @@ describe('CircleDetailComponent', () => {
     });
 
     it('should handle empty contests list', () => {
-      mockCircleService.getCircleContests.and.returnValue(of([]));
+      mockCircleService.getCircleContests.mockReturnValue(of([]));
 
       fixture.detectChanges();
 
@@ -153,21 +160,19 @@ describe('CircleDetailComponent', () => {
       expect(component.loadingContests()).toBe(false);
     });
 
-    it('should set loadingContests to true while loading', (done) => {
-      mockCircleService.getCircleContests.and.returnValue(of(mockContests));
+    it('should set loadingContests to true while loading', () => {
+      mockCircleService.getCircleContests.mockReturnValue(of(mockContests));
 
       fixture.detectChanges();
 
-      // After detectChanges, loadingContests should be false
       expect(component.loadingContests()).toBe(false);
-      done();
     });
   });
 
   describe('refreshContests', () => {
     beforeEach(() => {
-      mockCircleService.getCircle.and.returnValue(of(mockCircle));
-      mockCircleService.getCircleContests.and.returnValue(of(mockContests));
+      mockCircleService.getCircle.mockReturnValue(of(mockCircle));
+      mockCircleService.getCircleContests.mockReturnValue(of(mockContests));
       fixture.detectChanges();
     });
 
@@ -180,7 +185,7 @@ describe('CircleDetailComponent', () => {
 
     it('should not refresh if circle id is not available', () => {
       component.circle.set(null);
-      mockCircleService.getCircleContests.calls.reset();
+      mockCircleService.getCircleContests.mockClear();
 
       component.refreshContests();
 
@@ -190,8 +195,8 @@ describe('CircleDetailComponent', () => {
 
   describe('viewContest', () => {
     beforeEach(() => {
-      mockCircleService.getCircle.and.returnValue(of(mockCircle));
-      mockCircleService.getCircleContests.and.returnValue(of(mockContests));
+      mockCircleService.getCircle.mockReturnValue(of(mockCircle));
+      mockCircleService.getCircleContests.mockReturnValue(of(mockContests));
       fixture.detectChanges();
     });
 
@@ -208,8 +213,8 @@ describe('CircleDetailComponent', () => {
   });
   describe('createContest', () => {
     beforeEach(() => {
-      mockCircleService.getCircle.and.returnValue(of(mockCircle));
-      mockCircleService.getCircleContests.and.returnValue(of(mockContests));
+      mockCircleService.getCircle.mockReturnValue(of(mockCircle));
+      mockCircleService.getCircleContests.mockReturnValue(of(mockContests));
       fixture.detectChanges();
     });
 
@@ -227,8 +232,8 @@ describe('CircleDetailComponent', () => {
 
   describe('getJoinLink', () => {
     beforeEach(() => {
-      mockCircleService.getCircle.and.returnValue(of(mockCircle));
-      mockCircleService.getCircleContests.and.returnValue(of(mockContests));
+      mockCircleService.getCircle.mockReturnValue(of(mockCircle));
+      mockCircleService.getCircleContests.mockReturnValue(of(mockContests));
       fixture.detectChanges();
     });
 
@@ -241,13 +246,16 @@ describe('CircleDetailComponent', () => {
 
   describe('copyJoinLink', () => {
     beforeEach(() => {
-      mockCircleService.getCircle.and.returnValue(of(mockCircle));
-      mockCircleService.getCircleContests.and.returnValue(of(mockContests));
+      mockCircleService.getCircle.mockReturnValue(of(mockCircle));
+      mockCircleService.getCircleContests.mockReturnValue(of(mockContests));
       fixture.detectChanges();
 
-      spyOn(navigator.clipboard, 'writeText').and.returnValue(
-        Promise.resolve(),
-      );
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: {
+          writeText: vi.fn().mockResolvedValue(undefined),
+        },
+      });
     });
 
     it('should copy join link to clipboard', async () => {
@@ -255,9 +263,9 @@ describe('CircleDetailComponent', () => {
 
       expect(navigator.clipboard.writeText).toHaveBeenCalled();
       const call = (
-        navigator.clipboard.writeText as jasmine.Spy
-      ).calls.mostRecent();
-      expect(call.args[0]).toContain('/circles/1/join');
+        navigator.clipboard.writeText as ReturnType<typeof vi.fn>
+      ).mock.calls.at(-1);
+      expect(call?.[0]).toContain('/circles/1/join');
     });
 
     it('should set linkCopied signal to true temporarily', async () => {
@@ -273,8 +281,8 @@ describe('CircleDetailComponent', () => {
 
   describe('getMaxClout', () => {
     beforeEach(() => {
-      mockCircleService.getCircle.and.returnValue(of(mockCircle));
-      mockCircleService.getCircleContests.and.returnValue(of(mockContests));
+      mockCircleService.getCircle.mockReturnValue(of(mockCircle));
+      mockCircleService.getCircleContests.mockReturnValue(of(mockContests));
       fixture.detectChanges();
     });
 

--- a/angular/projects/predix/src/app/components/circle-list/circle-list.component.spec.ts
+++ b/angular/projects/predix/src/app/components/circle-list/circle-list.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { vi } from 'vitest';
 import { By } from '@angular/platform-browser';
 import { Router } from '@angular/router';
 import { of, throwError } from 'rxjs';
@@ -6,12 +7,15 @@ import { of, throwError } from 'rxjs';
 import { CircleListComponent } from './circle-list.component';
 import { CircleService } from '../../services/circle.service';
 import type { Circle } from '../../models/circle.model';
+import { createMockObject } from '../../../testing/create-mock-object';
 
 describe('CircleListComponent', () => {
+  const circleServiceMethods = ['listUserCircles'] as const;
+  const routerMethods = ['navigate'] as const;
   let fixture: ComponentFixture<CircleListComponent>;
   let component: CircleListComponent;
-  let mockCircleService: jasmine.SpyObj<CircleService>;
-  let mockRouter: jasmine.SpyObj<Router>;
+  let mockCircleService = createMockObject(circleServiceMethods);
+  let mockRouter = createMockObject(routerMethods);
 
   const mockCircle1: Circle = {
     id: 1,
@@ -34,16 +38,17 @@ describe('CircleListComponent', () => {
   };
 
   beforeEach(async () => {
-    mockCircleService = jasmine.createSpyObj('CircleService', [
-      'listUserCircles',
-    ]);
-    mockRouter = jasmine.createSpyObj('Router', ['navigate']);
+    mockCircleService = createMockObject(circleServiceMethods);
+    mockRouter = createMockObject(routerMethods);
 
     await TestBed.configureTestingModule({
       imports: [CircleListComponent],
       providers: [
-        { provide: CircleService, useValue: mockCircleService },
-        { provide: Router, useValue: mockRouter },
+        {
+          provide: CircleService,
+          useValue: mockCircleService as unknown as CircleService,
+        },
+        { provide: Router, useValue: mockRouter as unknown as Router },
       ],
     }).compileComponents();
 
@@ -57,7 +62,7 @@ describe('CircleListComponent', () => {
 
   describe('Initial Load Flow', () => {
     it('should load circles on init', () => {
-      mockCircleService.listUserCircles.and.returnValue(
+      mockCircleService.listUserCircles.mockReturnValue(
         of([mockCircle1, mockCircle2]),
       );
 
@@ -69,8 +74,8 @@ describe('CircleListComponent', () => {
     });
 
     it('should handle error on init', () => {
-      spyOn(console, 'error');
-      mockCircleService.listUserCircles.and.returnValue(
+      vi.spyOn(console, 'error');
+      mockCircleService.listUserCircles.mockReturnValue(
         throwError(() => new Error('Failed to fetch circles')),
       );
 
@@ -80,7 +85,7 @@ describe('CircleListComponent', () => {
       expect(component.circles()).toEqual([]);
       expect(console.error).toHaveBeenCalledWith(
         'Failed to load circles:',
-        jasmine.any(Error),
+        expect.any(Error),
       );
     });
   });
@@ -88,12 +93,12 @@ describe('CircleListComponent', () => {
   describe('Refresh Flow', () => {
     it('should call service and update circles on refresh', () => {
       // initial
-      mockCircleService.listUserCircles.and.returnValue(of([mockCircle1]));
+      mockCircleService.listUserCircles.mockReturnValue(of([mockCircle1]));
       fixture.detectChanges();
       expect(component.circles().length).toBe(1);
 
       // refresh with new data
-      mockCircleService.listUserCircles.and.returnValue(of([mockCircle2]));
+      mockCircleService.listUserCircles.mockReturnValue(of([mockCircle2]));
       component.refreshCircles();
 
       expect(mockCircleService.listUserCircles).toHaveBeenCalledTimes(2);
@@ -103,12 +108,12 @@ describe('CircleListComponent', () => {
     });
 
     it('should set loading state during refresh and reset after', () => {
-      mockCircleService.listUserCircles.and.returnValue(of([mockCircle1]));
+      mockCircleService.listUserCircles.mockReturnValue(of([mockCircle1]));
       fixture.detectChanges();
       expect(component.loading()).toBe(false);
 
       // Set up next call
-      mockCircleService.listUserCircles.and.returnValue(of([mockCircle2]));
+      mockCircleService.listUserCircles.mockReturnValue(of([mockCircle2]));
       component.refreshCircles();
 
       // After synchronous subscription, loading should be false again
@@ -116,11 +121,11 @@ describe('CircleListComponent', () => {
     });
 
     it('should handle errors during refresh', () => {
-      mockCircleService.listUserCircles.and.returnValue(of([mockCircle1]));
+      mockCircleService.listUserCircles.mockReturnValue(of([mockCircle1]));
       fixture.detectChanges();
 
-      spyOn(console, 'error');
-      mockCircleService.listUserCircles.and.returnValue(
+      vi.spyOn(console, 'error');
+      mockCircleService.listUserCircles.mockReturnValue(
         throwError(() => new Error('Network error')),
       );
 
@@ -129,14 +134,14 @@ describe('CircleListComponent', () => {
       expect(component.loading()).toBe(false);
       expect(console.error).toHaveBeenCalledWith(
         'Failed to load circles:',
-        jasmine.any(Error),
+        expect.any(Error),
       );
     });
   });
 
   describe('Template Rendering Flow', () => {
     it('should render refresh button', () => {
-      mockCircleService.listUserCircles.and.returnValue(of([]));
+      mockCircleService.listUserCircles.mockReturnValue(of([]));
       fixture.detectChanges();
 
       const refreshButton = fixture.debugElement.query(
@@ -147,8 +152,8 @@ describe('CircleListComponent', () => {
     });
 
     it('should call refreshCircles when refresh button is clicked', () => {
-      spyOn(component, 'refreshCircles');
-      mockCircleService.listUserCircles.and.returnValue(of([]));
+      vi.spyOn(component, 'refreshCircles');
+      mockCircleService.listUserCircles.mockReturnValue(of([]));
       fixture.detectChanges();
 
       const refreshButton = fixture.debugElement.query(
@@ -160,7 +165,7 @@ describe('CircleListComponent', () => {
     });
 
     it('should disable refresh button when loading', () => {
-      mockCircleService.listUserCircles.and.returnValue(of([]));
+      mockCircleService.listUserCircles.mockReturnValue(of([]));
       fixture.detectChanges();
 
       component.loading.set(true);
@@ -173,7 +178,7 @@ describe('CircleListComponent', () => {
     });
 
     it('should show "Refreshing..." text when loading and "Refresh" when not', () => {
-      mockCircleService.listUserCircles.and.returnValue(of([]));
+      mockCircleService.listUserCircles.mockReturnValue(of([]));
       fixture.detectChanges();
 
       component.loading.set(true);
@@ -192,7 +197,7 @@ describe('CircleListComponent', () => {
     });
 
     it('should toggle animate-spin class on icon based on loading', () => {
-      mockCircleService.listUserCircles.and.returnValue(of([]));
+      mockCircleService.listUserCircles.mockReturnValue(of([]));
       fixture.detectChanges();
 
       component.loading.set(true);

--- a/angular/projects/predix/src/app/components/contest-detail/contest-detail.component.spec.ts
+++ b/angular/projects/predix/src/app/components/contest-detail/contest-detail.component.spec.ts
@@ -1,17 +1,29 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { vi } from 'vitest';
 import { ContestDetailComponent } from './contest-detail.component';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ContestService } from '../../services/contest.service';
 import { AuthService } from '../../services/auth.service';
 import { of, throwError, Subject } from 'rxjs';
 import type { Contest, PayoutBreakdown } from '../../models/contest.model';
+import { createMockObject } from '../../../testing/create-mock-object';
 
 describe('ContestDetailComponent - Payout Breakdown', () => {
+  const contestServiceMethods = [
+    'getContest',
+    'makePrediction',
+    'lockContest',
+    'resolveContest',
+    'getPayoutBreakdown',
+    'streamContestDetails',
+  ] as const;
+  const authMethods = ['currentUser'] as const;
+  const routerMethods = ['navigate'] as const;
   let component: ContestDetailComponent;
   let fixture: ComponentFixture<ContestDetailComponent>;
-  let mockContestService: jasmine.SpyObj<ContestService>;
-  let mockAuthService: jasmine.SpyObj<AuthService>;
-  let mockRouter: jasmine.SpyObj<Router>;
+  let mockContestService = createMockObject(contestServiceMethods);
+  let mockAuthService = createMockObject(authMethods);
+  let mockRouter = createMockObject(routerMethods);
   let mockActivatedRoute: Partial<ActivatedRoute>;
 
   const mockResolvedContest: Contest = {
@@ -78,20 +90,13 @@ describe('ContestDetailComponent - Payout Breakdown', () => {
   };
 
   beforeEach(async () => {
-    mockContestService = jasmine.createSpyObj('ContestService', [
-      'getContest',
-      'makePrediction',
-      'lockContest',
-      'resolveContest',
-      'getPayoutBreakdown',
-      'streamContestDetails',
-    ]);
-    mockAuthService = jasmine.createSpyObj('AuthService', ['currentUser']);
-    mockRouter = jasmine.createSpyObj('Router', ['navigate']);
+    mockContestService = createMockObject(contestServiceMethods);
+    mockAuthService = createMockObject(authMethods);
+    mockRouter = createMockObject(routerMethods);
     mockActivatedRoute = {
       snapshot: {
         paramMap: {
-          get: jasmine.createSpy('get').and.callFake((key: string) => {
+          get: vi.fn().mockImplementation((key: string) => {
             if (key === 'id') return '1';
             if (key === 'circleId') return '1';
             return null;
@@ -100,7 +105,7 @@ describe('ContestDetailComponent - Payout Breakdown', () => {
       } as any,
     };
 
-    mockAuthService.currentUser.and.returnValue({
+    mockAuthService.currentUser.mockReturnValue({
       id: 1,
       username: 'alice',
       role: 'member',
@@ -109,21 +114,27 @@ describe('ContestDetailComponent - Payout Breakdown', () => {
     await TestBed.configureTestingModule({
       imports: [ContestDetailComponent],
       providers: [
-        { provide: ContestService, useValue: mockContestService },
-        { provide: AuthService, useValue: mockAuthService },
-        { provide: Router, useValue: mockRouter },
+        {
+          provide: ContestService,
+          useValue: mockContestService as unknown as ContestService,
+        },
+        {
+          provide: AuthService,
+          useValue: mockAuthService as unknown as AuthService,
+        },
+        { provide: Router, useValue: mockRouter as unknown as Router },
         { provide: ActivatedRoute, useValue: mockActivatedRoute },
       ],
     }).compileComponents();
 
     // Default mock for streamContestDetails (can be overridden in specific tests)
-    mockContestService.streamContestDetails.and.returnValue(
+    mockContestService.streamContestDetails.mockReturnValue(
       of({
         ...mockOpenContest,
         totals: { byOption: new Map() },
       }),
     );
-    mockContestService.getContest.and.returnValue(of(mockOpenContest));
+    mockContestService.getContest.mockReturnValue(of(mockOpenContest));
 
     fixture = TestBed.createComponent(ContestDetailComponent);
     component = fixture.componentInstance;
@@ -144,10 +155,10 @@ describe('ContestDetailComponent - Payout Breakdown', () => {
           ]),
         },
       };
-      mockContestService.streamContestDetails.and.returnValue(
+      mockContestService.streamContestDetails.mockReturnValue(
         of(contestWithTotals),
       );
-      mockContestService.getPayoutBreakdown.and.returnValue(
+      mockContestService.getPayoutBreakdown.mockReturnValue(
         of(mockPayoutBreakdown),
       );
 
@@ -166,7 +177,7 @@ describe('ContestDetailComponent - Payout Breakdown', () => {
         ...mockOpenContest,
         totals: { byOption: new Map() },
       };
-      mockContestService.streamContestDetails.and.returnValue(
+      mockContestService.streamContestDetails.mockReturnValue(
         of(contestWithTotals),
       );
 
@@ -179,32 +190,29 @@ describe('ContestDetailComponent - Payout Breakdown', () => {
       expect(mockContestService.getPayoutBreakdown).not.toHaveBeenCalled();
     });
 
-    it('should set payoutLoading signal to true while fetching', (done) => {
+    it('should set payoutLoading signal to true while fetching', async () => {
       const contestWithTotals = {
         ...mockResolvedContest,
         totals: { byOption: new Map() },
       };
-      mockContestService.streamContestDetails.and.returnValue(
+      mockContestService.streamContestDetails.mockReturnValue(
         of(contestWithTotals),
       );
-      mockContestService.getPayoutBreakdown.and.returnValue(
+      mockContestService.getPayoutBreakdown.mockReturnValue(
         of(mockPayoutBreakdown),
       );
 
       fixture.detectChanges();
 
-      // Check that payoutLoading is false after loading completes
-      setTimeout(() => {
-        expect(component.payoutLoading()).toBe(false);
-        done();
-      }, 0);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(component.payoutLoading()).toBe(false);
     });
 
     it('should handle payout breakdown fetch error', () => {
-      mockContestService.streamContestDetails.and.returnValue(
+      mockContestService.streamContestDetails.mockReturnValue(
         of({ ...mockResolvedContest, totals: { byOption: new Map() } }),
       );
-      mockContestService.getPayoutBreakdown.and.returnValue(
+      mockContestService.getPayoutBreakdown.mockReturnValue(
         throwError(() => ({
           error: { error: 'Failed to load payout breakdown' },
         })),
@@ -217,10 +225,10 @@ describe('ContestDetailComponent - Payout Breakdown', () => {
     });
 
     it('should handle generic payout breakdown fetch error', () => {
-      mockContestService.streamContestDetails.and.returnValue(
+      mockContestService.streamContestDetails.mockReturnValue(
         of({ ...mockResolvedContest, totals: { byOption: new Map() } }),
       );
-      mockContestService.getPayoutBreakdown.and.returnValue(
+      mockContestService.getPayoutBreakdown.mockReturnValue(
         throwError(() => new Error('Network error')),
       );
 
@@ -233,7 +241,7 @@ describe('ContestDetailComponent - Payout Breakdown', () => {
 
   describe('Payout Breakdown Not Shown for Non-Resolved Contests', () => {
     it('should not load payout breakdown when contest status is OPEN', () => {
-      mockContestService.streamContestDetails.and.returnValue(
+      mockContestService.streamContestDetails.mockReturnValue(
         of({ ...mockOpenContest, totals: { byOption: new Map() } }),
       );
 
@@ -249,7 +257,7 @@ describe('ContestDetailComponent - Payout Breakdown', () => {
         status: 'LOCKED',
         result_option_id: undefined,
       };
-      mockContestService.streamContestDetails.and.returnValue(
+      mockContestService.streamContestDetails.mockReturnValue(
         of({ ...lockedContest, totals: { byOption: new Map() } }),
       );
 
@@ -265,7 +273,7 @@ describe('ContestDetailComponent - Payout Breakdown', () => {
         status: 'EXPIRED',
         result_option_id: undefined,
       };
-      mockContestService.streamContestDetails.and.returnValue(
+      mockContestService.streamContestDetails.mockReturnValue(
         of({ ...closedContest, totals: { byOption: new Map() } }),
       );
 
@@ -278,7 +286,7 @@ describe('ContestDetailComponent - Payout Breakdown', () => {
 
   describe('Contest Resolution Flow', () => {
     it('should load payout breakdown after resolving contest', () => {
-      mockContestService.streamContestDetails.and.returnValue(
+      mockContestService.streamContestDetails.mockReturnValue(
         of({ ...mockOpenContest, totals: { byOption: new Map() } }),
       );
 
@@ -286,11 +294,11 @@ describe('ContestDetailComponent - Payout Breakdown', () => {
       expect(mockContestService.getPayoutBreakdown).not.toHaveBeenCalled();
 
       // Simulate resolution
-      mockContestService.streamContestDetails.and.returnValue(
+      mockContestService.streamContestDetails.mockReturnValue(
         of({ ...mockResolvedContest, totals: { byOption: new Map() } }),
       );
-      mockContestService.getContest.and.returnValue(of(mockResolvedContest)); // Add getContest mock for loadContest method
-      mockContestService.getPayoutBreakdown.and.returnValue(
+      mockContestService.getContest.mockReturnValue(of(mockResolvedContest)); // Add getContest mock for loadContest method
+      mockContestService.getPayoutBreakdown.mockReturnValue(
         of(mockPayoutBreakdown),
       );
 
@@ -301,10 +309,10 @@ describe('ContestDetailComponent - Payout Breakdown', () => {
     });
 
     it('should handle error when loading payout breakdown after resolution', () => {
-      mockContestService.streamContestDetails.and.returnValue(
+      mockContestService.streamContestDetails.mockReturnValue(
         of({ ...mockResolvedContest, totals: { byOption: new Map() } }),
       );
-      mockContestService.getPayoutBreakdown.and.returnValue(
+      mockContestService.getPayoutBreakdown.mockReturnValue(
         throwError(() => ({
           error: { error: 'Contest not found' },
         })),
@@ -331,10 +339,10 @@ describe('ContestDetailComponent - Payout Breakdown', () => {
     });
 
     it('should update all three signals when loading succeeds', () => {
-      mockContestService.streamContestDetails.and.returnValue(
+      mockContestService.streamContestDetails.mockReturnValue(
         of({ ...mockResolvedContest, totals: { byOption: new Map() } }),
       );
-      mockContestService.getPayoutBreakdown.and.returnValue(
+      mockContestService.getPayoutBreakdown.mockReturnValue(
         of(mockPayoutBreakdown),
       );
 
@@ -351,10 +359,10 @@ describe('ContestDetailComponent - Payout Breakdown', () => {
 
     it('should update signals correctly when loading fails', () => {
       const errorMessage = 'Connection timeout';
-      mockContestService.streamContestDetails.and.returnValue(
+      mockContestService.streamContestDetails.mockReturnValue(
         of({ ...mockResolvedContest, totals: { byOption: new Map() } }),
       );
-      mockContestService.getPayoutBreakdown.and.returnValue(
+      mockContestService.getPayoutBreakdown.mockReturnValue(
         throwError(() => ({
           error: { error: errorMessage },
         })),
@@ -374,7 +382,7 @@ describe('ContestDetailComponent - Payout Breakdown', () => {
         ...mockOpenContest,
         totals: { byOption: new Map() },
       };
-      mockContestService.streamContestDetails.and.returnValue(
+      mockContestService.streamContestDetails.mockReturnValue(
         of(contestWithTotals),
       );
 
@@ -392,21 +400,21 @@ describe('ContestDetailComponent - Payout Breakdown', () => {
         totals: { byOption: Map<number, { clout: number; count: number }> };
       };
       const pollSubject = new Subject<ContestWithTotals>();
-      mockContestService.streamContestDetails.and.returnValue(
+      mockContestService.streamContestDetails.mockReturnValue(
         pollSubject.asObservable(),
       );
 
       fixture.detectChanges();
 
       const subscription = (component as any).pollingSubscription;
-      spyOn(subscription, 'unsubscribe');
+      vi.spyOn(subscription, 'unsubscribe');
 
       fixture.destroy();
 
       expect(subscription.unsubscribe).toHaveBeenCalled();
     });
 
-    it('should update contest state on each poll emission', (done) => {
+    it('should update contest state on each poll emission', () => {
       const contestOpen = {
         ...mockOpenContest,
         totals: { byOption: new Map([[1, { clout: 100, count: 1 }]]) },
@@ -417,7 +425,7 @@ describe('ContestDetailComponent - Payout Breakdown', () => {
       };
 
       const pollSubject = new Subject<typeof contestOpen>();
-      mockContestService.streamContestDetails.and.returnValue(
+      mockContestService.streamContestDetails.mockReturnValue(
         pollSubject.asObservable(),
       );
 
@@ -432,7 +440,6 @@ describe('ContestDetailComponent - Payout Breakdown', () => {
       expect(component.contest()).toEqual(contestUpdated);
 
       pollSubject.complete();
-      done();
     });
 
     it('should load payout breakdown only once when contest becomes resolved', () => {
@@ -447,10 +454,10 @@ describe('ContestDetailComponent - Payout Breakdown', () => {
       };
 
       const pollSubject = new Subject<any>();
-      mockContestService.streamContestDetails.and.returnValue(
+      mockContestService.streamContestDetails.mockReturnValue(
         pollSubject.asObservable(),
       );
-      mockContestService.getPayoutBreakdown.and.returnValue(
+      mockContestService.getPayoutBreakdown.mockReturnValue(
         of(mockPayoutBreakdown),
       );
 

--- a/angular/projects/predix/src/app/components/contest-list/contest-list.component.spec.ts
+++ b/angular/projects/predix/src/app/components/contest-list/contest-list.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { vi } from 'vitest';
 import { ContestListComponent } from './contest-list.component';
 import { Router } from '@angular/router';
 import { CircleService } from '../../services/circle.service';
@@ -6,12 +7,18 @@ import { of, throwError } from 'rxjs';
 import type { Circle } from '../../models/circle.model';
 import type { Contest } from '../../models/contest.model';
 import { By } from '@angular/platform-browser';
+import { createMockObject } from '../../../testing/create-mock-object';
 
 describe('ContestListComponent', () => {
+  const circleServiceMethods = [
+    'listUserCircles',
+    'getCircleContests',
+  ] as const;
+  const routerMethods = ['navigate'] as const;
   let component: ContestListComponent;
   let fixture: ComponentFixture<ContestListComponent>;
-  let mockCircleService: jasmine.SpyObj<CircleService>;
-  let mockRouter: jasmine.SpyObj<Router>;
+  let mockCircleService = createMockObject(circleServiceMethods);
+  let mockRouter = createMockObject(routerMethods);
 
   const mockCircle1: Circle = {
     id: 1,
@@ -155,18 +162,24 @@ describe('ContestListComponent', () => {
     duration: '7d',
   };
 
+  const mockContestResponses = (responses: Record<number, Contest[]>) => {
+    mockCircleService.getCircleContests.mockImplementation((circleId: number) =>
+      of(responses[circleId] ?? []),
+    );
+  };
+
   beforeEach(async () => {
-    mockCircleService = jasmine.createSpyObj('CircleService', [
-      'listUserCircles',
-      'getCircleContests',
-    ]);
-    mockRouter = jasmine.createSpyObj('Router', ['navigate']);
+    mockCircleService = createMockObject(circleServiceMethods);
+    mockRouter = createMockObject(routerMethods);
 
     await TestBed.configureTestingModule({
       imports: [ContestListComponent],
       providers: [
-        { provide: CircleService, useValue: mockCircleService },
-        { provide: Router, useValue: mockRouter },
+        {
+          provide: CircleService,
+          useValue: mockCircleService as unknown as CircleService,
+        },
+        { provide: Router, useValue: mockRouter as unknown as Router },
       ],
     }).compileComponents();
 
@@ -180,15 +193,13 @@ describe('ContestListComponent', () => {
 
   describe('Contest Loading Flow', () => {
     it('should load contests from multiple circles on init', () => {
-      mockCircleService.listUserCircles.and.returnValue(
+      mockCircleService.listUserCircles.mockReturnValue(
         of([mockCircle1, mockCircle2]),
       );
-      mockCircleService.getCircleContests
-        .withArgs(1)
-        .and.returnValue(of([mockContest1, mockContest2]));
-      mockCircleService.getCircleContests
-        .withArgs(2)
-        .and.returnValue(of([mockContest3, mockContest4]));
+      mockContestResponses({
+        1: [mockContest1, mockContest2],
+        2: [mockContest3, mockContest4],
+      });
 
       fixture.detectChanges(); // Triggers ngOnInit
 
@@ -201,8 +212,8 @@ describe('ContestListComponent', () => {
     });
 
     it('should set loading to true initially, then false after completion', () => {
-      mockCircleService.listUserCircles.and.returnValue(of([mockCircle1]));
-      mockCircleService.getCircleContests.and.returnValue(of([mockContest1]));
+      mockCircleService.listUserCircles.mockReturnValue(of([mockCircle1]));
+      mockCircleService.getCircleContests.mockReturnValue(of([mockContest1]));
 
       expect(component.loading()).toBe(false); // Initial state
 
@@ -213,7 +224,7 @@ describe('ContestListComponent', () => {
     });
 
     it('should handle empty circles list', () => {
-      mockCircleService.listUserCircles.and.returnValue(of([]));
+      mockCircleService.listUserCircles.mockReturnValue(of([]));
 
       fixture.detectChanges();
 
@@ -224,16 +235,14 @@ describe('ContestListComponent', () => {
     });
 
     it('should handle mixed scenario with some circles having contests and others empty', () => {
-      mockCircleService.listUserCircles.and.returnValue(
+      mockCircleService.listUserCircles.mockReturnValue(
         of([mockCircle1, mockCircle2, mockCircle3]),
       );
-      mockCircleService.getCircleContests
-        .withArgs(1)
-        .and.returnValue(of([mockContest1]));
-      mockCircleService.getCircleContests.withArgs(2).and.returnValue(of([]));
-      mockCircleService.getCircleContests
-        .withArgs(3)
-        .and.returnValue(of([mockContest2]));
+      mockContestResponses({
+        1: [mockContest1],
+        2: [],
+        3: [mockContest2],
+      });
 
       fixture.detectChanges();
 
@@ -244,15 +253,13 @@ describe('ContestListComponent', () => {
     });
 
     it('should properly flatten nested contest arrays from multiple circles', () => {
-      mockCircleService.listUserCircles.and.returnValue(
+      mockCircleService.listUserCircles.mockReturnValue(
         of([mockCircle1, mockCircle2]),
       );
-      mockCircleService.getCircleContests
-        .withArgs(1)
-        .and.returnValue(of([mockContest1, mockContest2]));
-      mockCircleService.getCircleContests
-        .withArgs(2)
-        .and.returnValue(of([mockContest3]));
+      mockContestResponses({
+        1: [mockContest1, mockContest2],
+        2: [mockContest3],
+      });
 
       fixture.detectChanges();
 
@@ -270,15 +277,13 @@ describe('ContestListComponent', () => {
       // mockContest1: '2024-01-05T10:00:00Z' (newest)
       // mockContest3: '2024-01-04T10:00:00Z' (middle)
       // mockContest2: '2024-01-03T10:00:00Z' (oldest)
-      mockCircleService.listUserCircles.and.returnValue(
+      mockCircleService.listUserCircles.mockReturnValue(
         of([mockCircle1, mockCircle2]),
       );
-      mockCircleService.getCircleContests
-        .withArgs(1)
-        .and.returnValue(of([mockContest2])); // Oldest first
-      mockCircleService.getCircleContests
-        .withArgs(2)
-        .and.returnValue(of([mockContest1, mockContest3])); // Newest and middle
+      mockContestResponses({
+        1: [mockContest2],
+        2: [mockContest1, mockContest3],
+      });
 
       fixture.detectChanges();
 
@@ -293,8 +298,8 @@ describe('ContestListComponent', () => {
       const contest1 = { ...mockContest1, created_at: '2024-01-05T10:00:00Z' };
       const contest2 = { ...mockContest2, created_at: '2024-01-05T10:00:00Z' };
 
-      mockCircleService.listUserCircles.and.returnValue(of([mockCircle1]));
-      mockCircleService.getCircleContests.and.returnValue(
+      mockCircleService.listUserCircles.mockReturnValue(of([mockCircle1]));
+      mockCircleService.getCircleContests.mockReturnValue(
         of([contest1, contest2]),
       );
 
@@ -310,8 +315,8 @@ describe('ContestListComponent', () => {
 
   describe('Error Handling Flow', () => {
     it('should handle error when fetching circles fails', () => {
-      spyOn(console, 'error');
-      mockCircleService.listUserCircles.and.returnValue(
+      vi.spyOn(console, 'error');
+      mockCircleService.listUserCircles.mockReturnValue(
         throwError(() => new Error('Failed to fetch circles')),
       );
 
@@ -321,14 +326,14 @@ describe('ContestListComponent', () => {
       expect(component.contests()).toEqual([]);
       expect(console.error).toHaveBeenCalledWith(
         'Failed to load contests:',
-        jasmine.any(Error),
+        expect.any(Error),
       );
     });
 
     it('should handle error when fetching contests for a circle fails', () => {
-      spyOn(console, 'error');
-      mockCircleService.listUserCircles.and.returnValue(of([mockCircle1]));
-      mockCircleService.getCircleContests.and.returnValue(
+      vi.spyOn(console, 'error');
+      mockCircleService.listUserCircles.mockReturnValue(of([mockCircle1]));
+      mockCircleService.getCircleContests.mockReturnValue(
         throwError(() => new Error('Failed to fetch contests')),
       );
 
@@ -337,7 +342,7 @@ describe('ContestListComponent', () => {
       expect(component.loading()).toBe(false);
       expect(console.error).toHaveBeenCalledWith(
         'Failed to load contests:',
-        jasmine.any(Error),
+        expect.any(Error),
       );
     });
   });
@@ -394,16 +399,16 @@ describe('ContestListComponent', () => {
 
   describe('Refresh Flow', () => {
     it('should reload contests when refreshContests is called', () => {
-      mockCircleService.listUserCircles.and.returnValue(of([mockCircle1]));
-      mockCircleService.getCircleContests.and.returnValue(of([mockContest1]));
+      mockCircleService.listUserCircles.mockReturnValue(of([mockCircle1]));
+      mockCircleService.getCircleContests.mockReturnValue(of([mockContest1]));
 
       fixture.detectChanges(); // Initial load via ngOnInit
 
       expect(mockCircleService.listUserCircles).toHaveBeenCalledTimes(1);
 
       // Clear previous calls
-      mockCircleService.listUserCircles.calls.reset();
-      mockCircleService.getCircleContests.calls.reset();
+      mockCircleService.listUserCircles.mockClear();
+      mockCircleService.getCircleContests.mockClear();
 
       // Now refresh
       component.refreshContests();
@@ -413,8 +418,8 @@ describe('ContestListComponent', () => {
     });
 
     it('should set loading state during refresh', () => {
-      mockCircleService.listUserCircles.and.returnValue(of([mockCircle1]));
-      mockCircleService.getCircleContests.and.returnValue(of([mockContest1]));
+      mockCircleService.listUserCircles.mockReturnValue(of([mockCircle1]));
+      mockCircleService.getCircleContests.mockReturnValue(of([mockContest1]));
 
       fixture.detectChanges(); // Initial load
 
@@ -428,8 +433,8 @@ describe('ContestListComponent', () => {
 
     it('should update contests with new data on refresh', () => {
       // Initial load
-      mockCircleService.listUserCircles.and.returnValue(of([mockCircle1]));
-      mockCircleService.getCircleContests.and.returnValue(of([mockContest1]));
+      mockCircleService.listUserCircles.mockReturnValue(of([mockCircle1]));
+      mockCircleService.getCircleContests.mockReturnValue(of([mockContest1]));
 
       fixture.detectChanges();
 
@@ -437,8 +442,8 @@ describe('ContestListComponent', () => {
       expect(component.contests()[0]).toBe(mockContest1);
 
       // Update mock to return different data
-      mockCircleService.listUserCircles.and.returnValue(of([mockCircle2]));
-      mockCircleService.getCircleContests.and.returnValue(
+      mockCircleService.listUserCircles.mockReturnValue(of([mockCircle2]));
+      mockCircleService.getCircleContests.mockReturnValue(
         of([mockContest3, mockContest4]),
       );
 
@@ -450,14 +455,14 @@ describe('ContestListComponent', () => {
     });
 
     it('should handle errors during refresh', () => {
-      spyOn(console, 'error');
-      mockCircleService.listUserCircles.and.returnValue(of([mockCircle1]));
-      mockCircleService.getCircleContests.and.returnValue(of([mockContest1]));
+      vi.spyOn(console, 'error');
+      mockCircleService.listUserCircles.mockReturnValue(of([mockCircle1]));
+      mockCircleService.getCircleContests.mockReturnValue(of([mockContest1]));
 
       fixture.detectChanges(); // Initial load succeeds
 
       // Make next call fail
-      mockCircleService.listUserCircles.and.returnValue(
+      mockCircleService.listUserCircles.mockReturnValue(
         throwError(() => new Error('Network error')),
       );
 
@@ -466,7 +471,7 @@ describe('ContestListComponent', () => {
       expect(component.loading()).toBe(false);
       expect(console.error).toHaveBeenCalledWith(
         'Failed to load contests:',
-        jasmine.any(Error),
+        expect.any(Error),
       );
     });
   });
@@ -474,7 +479,7 @@ describe('ContestListComponent', () => {
   describe('Template Rendering Flow', () => {
     it('should show loading spinner when loading is true', () => {
       // Set up mocks to prevent ngOnInit errors
-      mockCircleService.listUserCircles.and.returnValue(of([]));
+      mockCircleService.listUserCircles.mockReturnValue(of([]));
 
       fixture.detectChanges(); // First detectChanges for ngOnInit
 
@@ -486,7 +491,7 @@ describe('ContestListComponent', () => {
     });
 
     it('should show empty state message when contests list is empty', () => {
-      mockCircleService.listUserCircles.and.returnValue(of([]));
+      mockCircleService.listUserCircles.mockReturnValue(of([]));
       fixture.detectChanges();
 
       const alert = fixture.debugElement.query(By.css('.alert-info'));
@@ -497,8 +502,8 @@ describe('ContestListComponent', () => {
     });
 
     it('should render contest cards with correct question text', () => {
-      mockCircleService.listUserCircles.and.returnValue(of([mockCircle1]));
-      mockCircleService.getCircleContests.and.returnValue(
+      mockCircleService.listUserCircles.mockReturnValue(of([mockCircle1]));
+      mockCircleService.getCircleContests.mockReturnValue(
         of([mockContest1, mockContest2]),
       );
       fixture.detectChanges();
@@ -514,8 +519,8 @@ describe('ContestListComponent', () => {
     });
 
     it('should display status badge with correct text', () => {
-      mockCircleService.listUserCircles.and.returnValue(of([mockCircle1]));
-      mockCircleService.getCircleContests.and.returnValue(of([mockContest1]));
+      mockCircleService.listUserCircles.mockReturnValue(of([mockCircle1]));
+      mockCircleService.getCircleContests.mockReturnValue(of([mockContest1]));
       fixture.detectChanges();
 
       const badge = fixture.debugElement.query(
@@ -525,15 +530,13 @@ describe('ContestListComponent', () => {
     });
 
     it('should display status badges with correct CSS classes', () => {
-      mockCircleService.listUserCircles.and.returnValue(
+      mockCircleService.listUserCircles.mockReturnValue(
         of([mockCircle1, mockCircle2]),
       );
-      mockCircleService.getCircleContests
-        .withArgs(1)
-        .and.returnValue(of([mockContest1, mockContest2]));
-      mockCircleService.getCircleContests
-        .withArgs(2)
-        .and.returnValue(of([mockContest3]));
+      mockContestResponses({
+        1: [mockContest1, mockContest2],
+        2: [mockContest3],
+      });
       fixture.detectChanges();
 
       const badges = fixture.debugElement.queryAll(
@@ -555,8 +558,8 @@ describe('ContestListComponent', () => {
     });
 
     it('should display total pot and house rake from mock data', () => {
-      mockCircleService.listUserCircles.and.returnValue(of([mockCircle1]));
-      mockCircleService.getCircleContests.and.returnValue(of([mockContest1]));
+      mockCircleService.listUserCircles.mockReturnValue(of([mockCircle1]));
+      mockCircleService.getCircleContests.mockReturnValue(of([mockContest1]));
       fixture.detectChanges();
 
       const compiled = fixture.nativeElement;
@@ -570,8 +573,8 @@ describe('ContestListComponent', () => {
     });
 
     it('should display correct prediction count', () => {
-      mockCircleService.listUserCircles.and.returnValue(of([mockCircle1]));
-      mockCircleService.getCircleContests.and.returnValue(of([mockContest1]));
+      mockCircleService.listUserCircles.mockReturnValue(of([mockCircle1]));
+      mockCircleService.getCircleContests.mockReturnValue(of([mockContest1]));
       fixture.detectChanges();
 
       const compiled = fixture.nativeElement;
@@ -579,8 +582,8 @@ describe('ContestListComponent', () => {
     });
 
     it('should display min stake value', () => {
-      mockCircleService.listUserCircles.and.returnValue(of([mockCircle1]));
-      mockCircleService.getCircleContests.and.returnValue(of([mockContest1]));
+      mockCircleService.listUserCircles.mockReturnValue(of([mockCircle1]));
+      mockCircleService.getCircleContests.mockReturnValue(of([mockContest1]));
       fixture.detectChanges();
 
       const compiled = fixture.nativeElement;
@@ -588,8 +591,8 @@ describe('ContestListComponent', () => {
     });
 
     it('should navigate when contest card is clicked', () => {
-      mockCircleService.listUserCircles.and.returnValue(of([mockCircle1]));
-      mockCircleService.getCircleContests.and.returnValue(of([mockContest1]));
+      mockCircleService.listUserCircles.mockReturnValue(of([mockCircle1]));
+      mockCircleService.getCircleContests.mockReturnValue(of([mockContest1]));
       fixture.detectChanges();
 
       const card = fixture.debugElement.query(By.css('.card'));
@@ -604,8 +607,8 @@ describe('ContestListComponent', () => {
     });
 
     it('should navigate with correct parameters when different contest card is clicked', () => {
-      mockCircleService.listUserCircles.and.returnValue(of([mockCircle2]));
-      mockCircleService.getCircleContests.and.returnValue(of([mockContest3]));
+      mockCircleService.listUserCircles.mockReturnValue(of([mockCircle2]));
+      mockCircleService.getCircleContests.mockReturnValue(of([mockContest3]));
       fixture.detectChanges();
 
       const card = fixture.debugElement.query(By.css('.card'));
@@ -620,8 +623,8 @@ describe('ContestListComponent', () => {
     });
 
     it('should display contest options as badges', () => {
-      mockCircleService.listUserCircles.and.returnValue(of([mockCircle1]));
-      mockCircleService.getCircleContests.and.returnValue(of([mockContest1]));
+      mockCircleService.listUserCircles.mockReturnValue(of([mockCircle1]));
+      mockCircleService.getCircleContests.mockReturnValue(of([mockContest1]));
       fixture.detectChanges();
 
       const optionBadges = fixture.debugElement.queryAll(
@@ -637,7 +640,7 @@ describe('ContestListComponent', () => {
     });
 
     it('should render refresh button', () => {
-      mockCircleService.listUserCircles.and.returnValue(of([]));
+      mockCircleService.listUserCircles.mockReturnValue(of([]));
       fixture.detectChanges();
 
       const refreshButton = fixture.debugElement.query(
@@ -648,8 +651,8 @@ describe('ContestListComponent', () => {
     });
 
     it('should call refreshContests when refresh button is clicked', () => {
-      spyOn(component, 'refreshContests');
-      mockCircleService.listUserCircles.and.returnValue(of([]));
+      vi.spyOn(component, 'refreshContests');
+      mockCircleService.listUserCircles.mockReturnValue(of([]));
       fixture.detectChanges();
 
       const refreshButton = fixture.debugElement.query(
@@ -661,7 +664,7 @@ describe('ContestListComponent', () => {
     });
 
     it('should disable refresh button when loading', () => {
-      mockCircleService.listUserCircles.and.returnValue(of([]));
+      mockCircleService.listUserCircles.mockReturnValue(of([]));
       fixture.detectChanges();
 
       component.loading.set(true);
@@ -674,7 +677,7 @@ describe('ContestListComponent', () => {
     });
 
     it('should enable refresh button when not loading', () => {
-      mockCircleService.listUserCircles.and.returnValue(of([]));
+      mockCircleService.listUserCircles.mockReturnValue(of([]));
       fixture.detectChanges();
 
       component.loading.set(false);
@@ -687,7 +690,7 @@ describe('ContestListComponent', () => {
     });
 
     it('should show "Refreshing..." text when loading', () => {
-      mockCircleService.listUserCircles.and.returnValue(of([]));
+      mockCircleService.listUserCircles.mockReturnValue(of([]));
       fixture.detectChanges();
 
       component.loading.set(true);
@@ -702,7 +705,7 @@ describe('ContestListComponent', () => {
     });
 
     it('should show "Refresh" text when not loading', () => {
-      mockCircleService.listUserCircles.and.returnValue(of([]));
+      mockCircleService.listUserCircles.mockReturnValue(of([]));
       fixture.detectChanges();
 
       component.loading.set(false);
@@ -715,7 +718,7 @@ describe('ContestListComponent', () => {
     });
 
     it('should have animate-spin class on icon when loading', () => {
-      mockCircleService.listUserCircles.and.returnValue(of([]));
+      mockCircleService.listUserCircles.mockReturnValue(of([]));
       fixture.detectChanges();
 
       component.loading.set(true);
@@ -726,7 +729,7 @@ describe('ContestListComponent', () => {
     });
 
     it('should not have animate-spin class on icon when not loading', () => {
-      mockCircleService.listUserCircles.and.returnValue(of([]));
+      mockCircleService.listUserCircles.mockReturnValue(of([]));
       fixture.detectChanges();
 
       component.loading.set(false);

--- a/angular/projects/predix/src/app/components/contest-stat/contest-stat.component.spec.ts
+++ b/angular/projects/predix/src/app/components/contest-stat/contest-stat.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { vi } from 'vitest';
 import { ContestStatComponent } from './contest-stat.component';
 import { By } from '@angular/platform-browser';
 
@@ -7,10 +8,7 @@ describe('ContestStatComponent', () => {
   let fixture: ComponentFixture<ContestStatComponent>;
 
   beforeEach(async () => {
-    try {
-      jasmine.clock().uninstall();
-    } catch (e) {}
-    jasmine.clock().install();
+    vi.useFakeTimers();
 
     await TestBed.configureTestingModule({
       imports: [ContestStatComponent],
@@ -26,7 +24,7 @@ describe('ContestStatComponent', () => {
   });
 
   afterEach(() => {
-    jasmine.clock().uninstall();
+    vi.useRealTimers();
   });
 
   it('should create', () => {
@@ -45,7 +43,7 @@ describe('ContestStatComponent', () => {
     expect(valueEl.textContent).toContain('100');
   });
 
-  it('should flash green (up) when value increases', () => {
+  it('should flash green (up) when value increases', async () => {
     // Initial state
     const valueEl = fixture.debugElement.query(By.css('.stat-value'));
     expect(valueEl.classes['text-green-500']).toBeFalsy();
@@ -60,13 +58,13 @@ describe('ContestStatComponent', () => {
     expect(valueEl.classes['text-red-500']).toBeFalsy();
 
     // Wait for flash duration
-    jasmine.clock().tick(1000);
+    await vi.advanceTimersByTimeAsync(1000);
     fixture.detectChanges();
 
     expect(valueEl.classes['text-green-500']).toBeFalsy();
   });
 
-  it('should flash red (down) when value decreases', () => {
+  it('should flash red (down) when value decreases', async () => {
     // Initial state
     const valueEl = fixture.debugElement.query(By.css('.stat-value'));
     expect(valueEl.classes['text-green-500']).toBeFalsy();
@@ -81,7 +79,7 @@ describe('ContestStatComponent', () => {
     expect(valueEl.classes['text-red-500']).toBe(true);
 
     // Wait for flash duration
-    jasmine.clock().tick(1000);
+    await vi.advanceTimersByTimeAsync(1000);
     fixture.detectChanges();
 
     expect(valueEl.classes['text-red-500']).toBeFalsy();

--- a/angular/projects/predix/src/app/components/join-circle/join-circle.component.spec.ts
+++ b/angular/projects/predix/src/app/components/join-circle/join-circle.component.spec.ts
@@ -1,23 +1,27 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { vi } from 'vitest';
 import { JoinCircleComponent } from './join-circle.component';
 import { ActivatedRoute, Router } from '@angular/router';
 import { CircleService } from '../../services/circle.service';
 import { of, throwError } from 'rxjs';
+import { createMockObject } from '../../../testing/create-mock-object';
 
 describe('JoinCircleComponent', () => {
+  const circleServiceMethods = ['joinCircle'] as const;
+  const routerMethods = ['navigate'] as const;
   let component: JoinCircleComponent;
   let fixture: ComponentFixture<JoinCircleComponent>;
-  let mockCircleService: jasmine.SpyObj<CircleService>;
-  let mockRouter: jasmine.SpyObj<Router>;
+  let mockCircleService = createMockObject(circleServiceMethods);
+  let mockRouter = createMockObject(routerMethods);
   let mockActivatedRoute: Partial<ActivatedRoute>;
 
   beforeEach(async () => {
-    mockCircleService = jasmine.createSpyObj('CircleService', ['joinCircle']);
-    mockRouter = jasmine.createSpyObj('Router', ['navigate']);
+    mockCircleService = createMockObject(circleServiceMethods);
+    mockRouter = createMockObject(routerMethods);
     mockActivatedRoute = {
       snapshot: {
         paramMap: {
-          get: jasmine.createSpy('get').and.returnValue('123'),
+          get: vi.fn().mockReturnValue('123'),
         },
       } as any,
     };
@@ -25,8 +29,11 @@ describe('JoinCircleComponent', () => {
     await TestBed.configureTestingModule({
       imports: [JoinCircleComponent],
       providers: [
-        { provide: CircleService, useValue: mockCircleService },
-        { provide: Router, useValue: mockRouter },
+        {
+          provide: CircleService,
+          useValue: mockCircleService as unknown as CircleService,
+        },
+        { provide: Router, useValue: mockRouter as unknown as Router },
         { provide: ActivatedRoute, useValue: mockActivatedRoute },
       ],
     }).compileComponents();
@@ -40,7 +47,7 @@ describe('JoinCircleComponent', () => {
   });
 
   it('should successfully join a circle', () => {
-    mockCircleService.joinCircle.and.returnValue(of(undefined));
+    mockCircleService.joinCircle.mockReturnValue(of(undefined));
 
     fixture.detectChanges();
 
@@ -52,7 +59,7 @@ describe('JoinCircleComponent', () => {
 
   it('should handle join circle error', () => {
     const errorResponse = { error: { error: 'User already a member' } };
-    mockCircleService.joinCircle.and.returnValue(
+    mockCircleService.joinCircle.mockReturnValue(
       throwError(() => errorResponse),
     );
 
@@ -65,7 +72,7 @@ describe('JoinCircleComponent', () => {
   });
 
   it('should navigate to circle detail on viewCircle', () => {
-    mockCircleService.joinCircle.and.returnValue(of(undefined));
+    mockCircleService.joinCircle.mockReturnValue(of(undefined));
     fixture.detectChanges();
 
     component['viewCircle']();
@@ -74,7 +81,7 @@ describe('JoinCircleComponent', () => {
   });
 
   it('should navigate to circles list on goToCircles', () => {
-    mockCircleService.joinCircle.and.returnValue(
+    mockCircleService.joinCircle.mockReturnValue(
       throwError(() => new Error('test error')),
     );
     fixture.detectChanges();

--- a/angular/projects/predix/src/app/components/register/register.component.spec.ts
+++ b/angular/projects/predix/src/app/components/register/register.component.spec.ts
@@ -1,42 +1,42 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { vi } from 'vitest';
 import { provideRouter, Router } from '@angular/router';
 import { provideLocationMocks } from '@angular/common/testing';
 import { of } from 'rxjs';
 
 import { RegisterComponent } from './register.component';
 import { AuthService, type LoginResponse } from '../../services/auth.service';
+import { createMockObject } from '../../../testing/create-mock-object';
 
 describe('RegisterComponent', () => {
+  const authMethods = ['isAuthenticated', 'register'] as const;
   let fixture: ComponentFixture<RegisterComponent>;
   let component: RegisterComponent;
-  let auth: jasmine.SpyObj<AuthService>;
+  let auth = createMockObject(authMethods);
   let router: Router;
 
   beforeEach(async () => {
-    auth = jasmine.createSpyObj<AuthService>('AuthService', [
-      'isAuthenticated',
-      'register',
-    ]);
+    auth = createMockObject(authMethods);
     const loginResponse: LoginResponse = {
       token: 'token',
       user: { id: 1, username: 'alice', role: 'member' },
     };
-    auth.isAuthenticated.and.returnValue(false);
-    auth.register.and.returnValue(of(loginResponse));
+    auth.isAuthenticated.mockReturnValue(false);
+    auth.register.mockReturnValue(of(loginResponse));
 
     await TestBed.configureTestingModule({
       imports: [RegisterComponent],
       providers: [
         provideRouter([]),
         provideLocationMocks(),
-        { provide: AuthService, useValue: auth },
+        { provide: AuthService, useValue: auth as unknown as AuthService },
       ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(RegisterComponent);
     component = fixture.componentInstance;
     router = TestBed.inject(Router);
-    spyOn(router, 'navigateByUrl');
+    vi.spyOn(router, 'navigateByUrl');
     fixture.detectChanges();
   });
 

--- a/angular/projects/predix/src/app/components/stake-adjustment/stake-adjustment.component.spec.ts
+++ b/angular/projects/predix/src/app/components/stake-adjustment/stake-adjustment.component.spec.ts
@@ -107,7 +107,7 @@ describe('StakeAdjustmentComponent', () => {
   });
 
   describe('Stake Updates via Input', () => {
-    it('should emit stakeChanged when input value changes', (done) => {
+    it('should emit stakeChanged when input value changes', async () => {
       const input = wrapperFixture.debugElement.query(
         By.css('input[type="number"]'),
       ).nativeElement;
@@ -116,10 +116,8 @@ describe('StakeAdjustmentComponent', () => {
       input.dispatchEvent(new Event('input'));
       wrapperFixture.detectChanges();
 
-      wrapperFixture.whenStable().then(() => {
-        expect(wrapperComponent.stakeChangedValue).toBe(2000);
-        done();
-      });
+      await wrapperFixture.whenStable();
+      expect(wrapperComponent.stakeChangedValue).toBe(2000);
     });
 
     it('should update displayed stake when config changes', () => {
@@ -155,57 +153,47 @@ describe('StakeAdjustmentComponent', () => {
   });
 
   describe('Stake Adjustment via Buttons', () => {
-    it('should adjust stake up by 100', (done) => {
+    it('should adjust stake up by 100', async () => {
       const buttons = wrapperFixture.debugElement.queryAll(By.css('button'));
       // +100 is the 4th button
       buttons[3].nativeElement.click();
       wrapperFixture.detectChanges();
 
-      wrapperFixture.whenStable().then(() => {
-        // Component logic would add 100 to current stake
-        expect(wrapperComponent.stakeChangedValue).toBe(1100);
-        done();
-      });
+      await wrapperFixture.whenStable();
+      expect(wrapperComponent.stakeChangedValue).toBe(1100);
     });
 
-    it('should adjust stake down by 100', (done) => {
+    it('should adjust stake down by 100', async () => {
       const buttons = wrapperFixture.debugElement.queryAll(By.css('button'));
       // -100 is the 1st button
       buttons[0].nativeElement.click();
       wrapperFixture.detectChanges();
 
-      wrapperFixture.whenStable().then(() => {
-        expect(wrapperComponent.stakeChangedValue).toBe(900);
-        done();
-      });
+      await wrapperFixture.whenStable();
+      expect(wrapperComponent.stakeChangedValue).toBe(900);
     });
 
-    it('should adjust stake up by 1000', (done) => {
+    it('should adjust stake up by 1000', async () => {
       const buttons = wrapperFixture.debugElement.queryAll(By.css('button'));
       // +1000 is the 5th button
       buttons[4].nativeElement.click();
       wrapperFixture.detectChanges();
 
-      wrapperFixture.whenStable().then(() => {
-        expect(wrapperComponent.stakeChangedValue).toBe(2000);
-        done();
-      });
+      await wrapperFixture.whenStable();
+      expect(wrapperComponent.stakeChangedValue).toBe(2000);
     });
 
-    it('should adjust stake down by 1000', (done) => {
+    it('should adjust stake down by 1000', async () => {
       const buttons = wrapperFixture.debugElement.queryAll(By.css('button'));
       // -1000 is the 2nd button
       buttons[1].nativeElement.click();
       wrapperFixture.detectChanges();
 
-      wrapperFixture.whenStable().then(() => {
-        // Current stake is 1000, min stake is 100, so 1000 - 1000 = 0 but clamped to 100
-        expect(wrapperComponent.stakeChangedValue).toBe(100);
-        done();
-      });
+      await wrapperFixture.whenStable();
+      expect(wrapperComponent.stakeChangedValue).toBe(100);
     });
 
-    it('should clamp to minimum stake when adjusting down', (done) => {
+    it('should clamp to minimum stake when adjusting down', async () => {
       wrapperComponent.config.set({
         minStake: 100,
         currentStake: 150,
@@ -218,13 +206,11 @@ describe('StakeAdjustmentComponent', () => {
       buttons[0].nativeElement.click();
       wrapperFixture.detectChanges();
 
-      wrapperFixture.whenStable().then(() => {
-        expect(wrapperComponent.stakeChangedValue).toBe(100);
-        done();
-      });
+      await wrapperFixture.whenStable();
+      expect(wrapperComponent.stakeChangedValue).toBe(100);
     });
 
-    it('should clamp large decrements to minimum stake', (done) => {
+    it('should clamp large decrements to minimum stake', async () => {
       wrapperComponent.config.set({
         minStake: 100,
         currentStake: 500,
@@ -237,10 +223,8 @@ describe('StakeAdjustmentComponent', () => {
       buttons[2].nativeElement.click();
       wrapperFixture.detectChanges();
 
-      wrapperFixture.whenStable().then(() => {
-        expect(wrapperComponent.stakeChangedValue).toBe(100);
-        done();
-      });
+      await wrapperFixture.whenStable();
+      expect(wrapperComponent.stakeChangedValue).toBe(100);
     });
   });
 
@@ -322,7 +306,7 @@ describe('StakeAdjustmentComponent', () => {
   });
 
   describe('Form Submission', () => {
-    it('should emit predictionSubmitted when submit button clicked', (done) => {
+    it('should emit predictionSubmitted when submit button clicked', async () => {
       const submitButton = wrapperFixture.debugElement.queryAll(
         By.css('button'),
       );
@@ -331,13 +315,11 @@ describe('StakeAdjustmentComponent', () => {
       placeButton.nativeElement.click();
       wrapperFixture.detectChanges();
 
-      wrapperFixture.whenStable().then(() => {
-        expect(wrapperComponent.predictionSubmittedCalled).toBe(true);
-        done();
-      });
+      await wrapperFixture.whenStable();
+      expect(wrapperComponent.predictionSubmittedCalled).toBe(true);
     });
 
-    it('should emit predictionSubmitted once per click', (done) => {
+    it('should emit predictionSubmitted once per click', async () => {
       let emitCount = 0;
       wrapperComponent.onPredictionSubmitted = () => {
         emitCount++;
@@ -351,10 +333,8 @@ describe('StakeAdjustmentComponent', () => {
       placeButton.nativeElement.click();
       wrapperFixture.detectChanges();
 
-      wrapperFixture.whenStable().then(() => {
-        expect(emitCount).toBe(1);
-        done();
-      });
+      await wrapperFixture.whenStable();
+      expect(emitCount).toBe(1);
     });
   });
 
@@ -389,7 +369,7 @@ describe('StakeAdjustmentComponent', () => {
   });
 
   describe('Integration Scenarios', () => {
-    it('should handle rapid stake changes', (done) => {
+    it('should handle rapid stake changes', async () => {
       const input = wrapperFixture.debugElement.query(
         By.css('input[type="number"]'),
       ).nativeElement;
@@ -407,13 +387,11 @@ describe('StakeAdjustmentComponent', () => {
       input.dispatchEvent(new Event('input'));
       wrapperFixture.detectChanges();
 
-      wrapperFixture.whenStable().then(() => {
-        expect(wrapperComponent.stakeChangedValue).toBe(2500);
-        done();
-      });
+      await wrapperFixture.whenStable();
+      expect(wrapperComponent.stakeChangedValue).toBe(2500);
     });
 
-    it('should handle mixed input and button adjustments', (done) => {
+    it('should handle mixed input and button adjustments', async () => {
       const input = wrapperFixture.debugElement.query(
         By.css('input[type="number"]'),
       ).nativeElement;
@@ -423,29 +401,22 @@ describe('StakeAdjustmentComponent', () => {
       input.dispatchEvent(new Event('input'));
       wrapperFixture.detectChanges();
 
-      wrapperFixture.whenStable().then(() => {
-        // After input, stakeChangedValue should be 2000
-        expect(wrapperComponent.stakeChangedValue).toBe(2000);
+      await wrapperFixture.whenStable();
+      expect(wrapperComponent.stakeChangedValue).toBe(2000);
 
-        // Update config to reflect the new stake
-        wrapperComponent.config.set({
-          minStake: 100,
-          currentStake: 2000,
-          isLoading: false,
-        });
-        wrapperFixture.detectChanges();
-
-        // Then button adjustment
-        const buttons = wrapperFixture.debugElement.queryAll(By.css('button'));
-        buttons[4].nativeElement.click(); // +1000
-        wrapperFixture.detectChanges();
-
-        wrapperFixture.whenStable().then(() => {
-          // 2000 + 1000 = 3000
-          expect(wrapperComponent.stakeChangedValue).toBe(3000);
-          done();
-        });
+      wrapperComponent.config.set({
+        minStake: 100,
+        currentStake: 2000,
+        isLoading: false,
       });
+      wrapperFixture.detectChanges();
+
+      const buttons = wrapperFixture.debugElement.queryAll(By.css('button'));
+      buttons[4].nativeElement.click();
+      wrapperFixture.detectChanges();
+
+      await wrapperFixture.whenStable();
+      expect(wrapperComponent.stakeChangedValue).toBe(3000);
     });
   });
 });

--- a/angular/projects/predix/src/app/services/circle.service.spec.ts
+++ b/angular/projects/predix/src/app/services/circle.service.spec.ts
@@ -140,7 +140,9 @@ describe('CircleService', () => {
       const circleId = 1;
 
       service.getCircleContests(circleId).subscribe({
-        next: () => fail('should have failed'),
+        next: () => {
+          throw new Error('should have failed');
+        },
         error: (error) => {
           expect(error.status).toBe(500);
         },

--- a/angular/projects/predix/src/app/services/contest.service.spec.ts
+++ b/angular/projects/predix/src/app/services/contest.service.spec.ts
@@ -1,10 +1,10 @@
 import { TestBed } from '@angular/core/testing';
+import { vi } from 'vitest';
 import {
   HttpTestingController,
   provideHttpClientTesting,
 } from '@angular/common/http/testing';
-import { TestScheduler } from 'rxjs/testing';
-import { of } from 'rxjs';
+import { firstValueFrom } from 'rxjs';
 import { take } from 'rxjs/operators';
 import { ContestService } from './contest.service';
 import { environment } from '../../environments/environment';
@@ -17,23 +17,24 @@ describe('ContestService', () => {
   let httpMock: HttpTestingController;
   const apiUrl = `${environment.apiUrl}/protected`;
   const mockAuthService = {
-    token: jasmine.createSpy('token').and.returnValue('test-token'),
+    token: vi.fn().mockReturnValue('test-token'),
   };
-  let mockEventSource: any;
-  let EventSourceSpy: jasmine.Spy;
+  let mockEventSource: MockEventSource;
+
+  class MockEventSource {
+    onopen: (() => void) | null = null;
+    onerror: ((error: unknown) => void) | null = null;
+    addEventListener = vi.fn();
+    close = vi.fn();
+    readyState = 1;
+
+    constructor(public url: string) {
+      mockEventSource = this;
+    }
+  }
 
   beforeEach(() => {
-    mockEventSource = {
-      onopen: null,
-      onerror: null,
-      addEventListener: jasmine.createSpy('addEventListener'),
-      close: jasmine.createSpy('close'),
-      readyState: 1,
-    };
-    EventSourceSpy = jasmine
-      .createSpy('EventSource')
-      .and.returnValue(mockEventSource);
-    (window as any).EventSource = EventSourceSpy;
+    (window as any).EventSource = MockEventSource as typeof EventSource;
 
     TestBed.configureTestingModule({
       providers: [
@@ -53,7 +54,7 @@ describe('ContestService', () => {
   });
 
   describe('getContest', () => {
-    it('should fetch a contest by circleId and contestId', (done) => {
+    it('should fetch a contest by circleId and contestId', async () => {
       const circleId = 1;
       const contestId = 42;
       const mockContest: Contest = {
@@ -75,23 +76,21 @@ describe('ContestService', () => {
         duration: '1d',
       };
 
-      service.getContest(circleId, contestId).subscribe({
-        next: (contest) => {
-          expect(contest).toEqual(mockContest);
-          done();
-        },
-      });
+      const contestPromise = firstValueFrom(
+        service.getContest(circleId, contestId),
+      );
 
       const req = httpMock.expectOne(
         `${apiUrl}/circles/${circleId}/contests/${contestId}`,
       );
       expect(req.request.method).toBe('GET');
       req.flush(mockContest);
+      await expect(contestPromise).resolves.toEqual(mockContest);
     });
   });
 
   describe('streamContestDetails', () => {
-    it('should stream contest updates with totals', (done) => {
+    it('should stream contest updates with totals', async () => {
       const circleId = 1;
       const contestId = 42;
       const mockContest: Contest = {
@@ -126,27 +125,20 @@ describe('ContestService', () => {
         duration: '1d',
       };
 
-      service
-        .streamContestDetails(circleId, contestId)
-        .pipe(take(1))
-        .subscribe({
-          next: (result) => {
-            expect(result.id).toBe(contestId);
-            expect(result.totals.byOption.get(1)?.clout).toBe(80);
-            expect(result.totals.byOption.get(1)?.count).toBe(2);
-            done();
-          },
-        });
+      const resultPromise = firstValueFrom(
+        service.streamContestDetails(circleId, contestId).pipe(take(1)),
+      );
 
-      setTimeout(() => {
-        if (mockEventSource.onopen) {
-          mockEventSource.onopen();
-        }
-        const req = httpMock.expectOne(
-          `${apiUrl}/circles/${circleId}/contests/${contestId}`,
-        );
-        req.flush(mockContest);
-      }, 0);
+      mockEventSource.onopen?.();
+      const req = httpMock.expectOne(
+        `${apiUrl}/circles/${circleId}/contests/${contestId}`,
+      );
+      req.flush(mockContest);
+
+      const result = await resultPromise;
+      expect(result.id).toBe(contestId);
+      expect(result.totals.byOption.get(1)?.clout).toBe(80);
+      expect(result.totals.byOption.get(1)?.count).toBe(2);
     });
   });
 });

--- a/angular/projects/predix/src/testing/create-mock-object.ts
+++ b/angular/projects/predix/src/testing/create-mock-object.ts
@@ -1,0 +1,13 @@
+import { vi } from 'vitest';
+
+export type MockObject<T extends readonly string[]> = {
+  [K in T[number]]: ReturnType<typeof vi.fn>;
+};
+
+export function createMockObject<const T extends readonly string[]>(
+  methods: T,
+): MockObject<T> {
+  return Object.fromEntries(
+    methods.map((method) => [method, vi.fn()]),
+  ) as MockObject<T>;
+}

--- a/angular/projects/predix/tsconfig.app.json
+++ b/angular/projects/predix/tsconfig.app.json
@@ -7,5 +7,5 @@
     "types": []
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.spec.ts"]
+  "exclude": ["src/**/*.spec.ts", "src/testing/**/*.ts"]
 }

--- a/angular/projects/predix/tsconfig.spec.json
+++ b/angular/projects/predix/tsconfig.spec.json
@@ -1,10 +1,8 @@
-/* To learn more about Typescript configuration file: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html. */
-/* To learn more about Angular compiler options: https://angular.dev/reference/configs/angular-compiler-options. */
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "../../out-tsc/spec",
-    "types": ["jasmine"]
+    "types": ["vitest/globals"]
   },
   "include": ["src/**/*.d.ts", "src/**/*.spec.ts"]
 }

--- a/angular/projects/predix/vitest-base.config.ts
+++ b/angular/projects/predix/vitest-base.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Write coverage to a known location relative to the config file so the
+// globalSetup teardown can reliably find it.
+const reportsDirectory = join(__dirname, '.vitest-coverage');
+
+export default defineConfig({
+  test: {
+    coverage: {
+      reportsDirectory,
+    },
+    // Always wire the global setup — teardown is a no-op when not under
+    // `bazel coverage` (checks COVERAGE_OUTPUT_FILE at runtime).
+    globalSetup: [join(__dirname, 'vitest-global-setup.ts')],
+  },
+});

--- a/angular/projects/predix/vitest-global-setup.ts
+++ b/angular/projects/predix/vitest-global-setup.ts
@@ -1,0 +1,33 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export async function teardown() {
+  const coverageOutputFile = process.env['COVERAGE_OUTPUT_FILE'];
+  // No-op when not running under `bazel coverage`.
+  if (!coverageOutputFile) return;
+
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const lcovSrc = join(__dirname, '.vitest-coverage', 'lcov.info');
+
+  if (!existsSync(lcovSrc)) {
+    process.stderr.write(
+      `[vitest-coverage] lcov file not found at: ${lcovSrc}\n`,
+    );
+    return;
+  }
+
+  // The Angular CLI's vitest runner sets root=workspaceRoot (angular/), so
+  // coverage paths are relative to angular/ rather than the repo root.
+  // Bazel's instrumentation_filter and lcov aggregator expect paths prefixed
+  // with "angular/", so we rewrite SF: lines before emitting.
+  const content = readFileSync(lcovSrc, 'utf-8');
+  const fixed = content.replace(/^(SF:)(?!angular\/)/gm, '$1angular/');
+
+  mkdirSync(dirname(coverageOutputFile), { recursive: true });
+  writeFileSync(coverageOutputFile, fixed, 'utf-8');
+  const sfCount = fixed.split('\n').filter((l) => l.startsWith('SF:')).length;
+  process.stderr.write(
+    `[vitest-coverage] Wrote ${sfCount} SF: entries to: ${coverageOutputFile}\n`,
+  );
+}

--- a/angular/projects/tailwind-sample/BUILD.bazel
+++ b/angular/projects/tailwind-sample/BUILD.bazel
@@ -17,6 +17,14 @@ copy_to_bin(
     ),
 )
 
+copy_to_bin(
+    name = "vitest_config_files",
+    srcs = [
+        "vitest-base.config.ts",
+        "vitest-global-setup.ts",
+    ],
+)
+
 process_styles(
     name = "processed_styles",
     src = "src/styles.css",
@@ -48,9 +56,10 @@ ng_test(
     srcs = [
         ":processed_styles",
         ":srcs",
+        ":vitest_config_files",
     ],
-    karma = True,
     tailwindcss = True,
+    vitest = True,
     zonejs = True,
     deps = [
         "//angular:node_modules/daisyui",

--- a/angular/projects/tailwind-sample/tsconfig.spec.json
+++ b/angular/projects/tailwind-sample/tsconfig.spec.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "../../out-tsc/spec",
-    "types": ["jasmine"]
+    "types": ["vitest/globals"]
   },
-  "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]
+  "include": ["src/**/*.d.ts", "src/**/*.spec.ts"]
 }

--- a/angular/projects/tailwind-sample/vitest-base.config.ts
+++ b/angular/projects/tailwind-sample/vitest-base.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Write coverage to a known location relative to the config file so the
+// globalSetup teardown can reliably find it.
+const reportsDirectory = join(__dirname, '.vitest-coverage');
+
+export default defineConfig({
+  test: {
+    coverage: {
+      reportsDirectory,
+    },
+    // Always wire the global setup — teardown is a no-op when not under
+    // `bazel coverage` (checks COVERAGE_OUTPUT_FILE at runtime).
+    globalSetup: [join(__dirname, 'vitest-global-setup.ts')],
+  },
+});

--- a/angular/projects/tailwind-sample/vitest-global-setup.ts
+++ b/angular/projects/tailwind-sample/vitest-global-setup.ts
@@ -1,0 +1,33 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export async function teardown() {
+  const coverageOutputFile = process.env['COVERAGE_OUTPUT_FILE'];
+  // No-op when not running under `bazel coverage`.
+  if (!coverageOutputFile) return;
+
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const lcovSrc = join(__dirname, '.vitest-coverage', 'lcov.info');
+
+  if (!existsSync(lcovSrc)) {
+    process.stderr.write(
+      `[vitest-coverage] lcov file not found at: ${lcovSrc}\n`,
+    );
+    return;
+  }
+
+  // The Angular CLI's vitest runner sets root=workspaceRoot (angular/), so
+  // coverage paths are relative to angular/ rather than the repo root.
+  // Bazel's instrumentation_filter and lcov aggregator expect paths prefixed
+  // with "angular/", so we rewrite SF: lines before emitting.
+  const content = readFileSync(lcovSrc, 'utf-8');
+  const fixed = content.replace(/^(SF:)(?!angular\/)/gm, '$1angular/');
+
+  mkdirSync(dirname(coverageOutputFile), { recursive: true });
+  writeFileSync(coverageOutputFile, fixed, 'utf-8');
+  const sfCount = fixed.split('\n').filter((l) => l.startsWith('SF:')).length;
+  process.stderr.write(
+    `[vitest-coverage] Wrote ${sfCount} SF: entries to: ${coverageOutputFile}\n`,
+  );
+}


### PR DESCRIPTION
## Summary
- migrate the remaining Angular app test targets from Karma-era setup to the Vitest-based `@angular/build:unit-test` flow
- add per-app Vitest config/setup files and update affected `mindreadr`/`predix` specs for Vitest-compatible async and mocking behavior
- ignore `flake.lock` in Prettier so the repo format entrypoint succeeds again

## Verification
- `bazel run gazelle`
- `bwrap --dev-bind / / --bind /run/current-system/sw/bin /bin /bin/bash -lc 'cd /home/tacascer/Projects/bazel-repo && bash /home/tacascer/Projects/bazel-repo/bazel-out/bazel_env-opt/bin/tools/bazel_env/bin/format'`
- `bazel test --shell_executable=/run/current-system/sw/bin/bash --action_env=PATH=/run/current-system/sw/bin:/usr/bin:/bin --host_action_env=PATH=/run/current-system/sw/bin:/usr/bin:/bin --test_env=PATH=/run/current-system/sw/bin:/usr/bin:/bin //angular/projects/nicknamer:test //angular/projects/tailwind-sample:test //angular/projects/mindreadr:test //angular/projects/predix:test`
- `bwrap --dev-bind / / --bind /run/current-system/sw/bin /bin /bin/bash -lc 'cd /home/tacascer/Projects/bazel-repo && bazel run //tools/coverage -- //angular/projects/nicknamer:test'`
- `bazel coverage --shell_executable=/run/current-system/sw/bin/bash --action_env=PATH=/run/current-system/sw/bin:/usr/bin:/bin --host_action_env=PATH=/run/current-system/sw/bin:/usr/bin:/bin --test_env=PATH=/run/current-system/sw/bin:/usr/bin:/bin //angular/projects/predix:test`

## Notes
- preserved the unrelated pre-team `nicknamer2` BUILD drift on local backup branch `backup/pre-team-nicknamer2-build-drift`; it is intentionally not part of this PR
- `tools/coverage` still skips HTML output when `genhtml` is unavailable, but LCOV generation passes
