### PR TITLE
feat(angular): add pinyin-hanzi learning app

### DIFF
--- a/angular/angular.json
+++ b/angular/angular.json
@@ -73,6 +73,76 @@
         }
       }
     },
+    "pinyin-hanzi": {
+      "projectType": "application",
+      "schematics": {},
+      "root": "projects/pinyin-hanzi",
+      "sourceRoot": "projects/pinyin-hanzi/src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "builder": "@angular/build:application",
+          "options": {
+            "browser": "projects/pinyin-hanzi/src/main.ts",
+            "tsConfig": "projects/pinyin-hanzi/tsconfig.app.json",
+            "assets": [
+              {
+                "glob": "**/*",
+                "input": "projects/pinyin-hanzi/public"
+              }
+            ],
+            "styles": ["projects/pinyin-hanzi/src/styles.css"]
+          },
+          "configurations": {
+            "production": {
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "500kB",
+                  "maximumError": "1MB"
+                },
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "4kB",
+                  "maximumError": "8kB"
+                }
+              ],
+              "outputHashing": "all"
+            },
+            "development": {
+              "optimization": false,
+              "extractLicenses": false,
+              "sourceMap": true
+            }
+          },
+          "defaultConfiguration": "production"
+        },
+        "serve": {
+          "builder": "@angular/build:dev-server",
+          "configurations": {
+            "production": {
+              "buildTarget": "pinyin-hanzi:build:production"
+            },
+            "development": {
+              "buildTarget": "pinyin-hanzi:build:development"
+            }
+          },
+          "defaultConfiguration": "development"
+        },
+        "extract-i18n": {
+          "builder": "@angular/build:extract-i18n"
+        },
+        "test": {
+          "builder": "@angular/build:unit-test",
+          "options": {
+            "tsConfig": "projects/pinyin-hanzi/tsconfig.spec.json",
+            "coverage": true,
+            "coverageReporters": ["lcovonly"],
+            "runnerConfig": "projects/pinyin-hanzi/vitest-base.config.ts"
+          }
+        }
+      }
+    },
     "tailwind-sample": {
       "projectType": "application",
       "schematics": {},

--- a/angular/projects/pinyin-hanzi/BUILD.bazel
+++ b/angular/projects/pinyin-hanzi/BUILD.bazel
@@ -1,0 +1,42 @@
+load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("//angular/bzl:ng.bzl", "ng_application", "ng_test")
+
+# aspect:generation_mode update_only
+package(default_visibility = ["//visibility:public"])
+
+exports_files([
+    "tsconfig.app.json",
+    "tsconfig.spec.json",
+])
+
+copy_to_bin(
+    name = "srcs",
+    srcs = glob(
+        ["src/**/*"],
+        exclude = ["dist/"],
+    ),
+)
+
+copy_to_bin(
+    name = "vitest_config_files",
+    srcs = [
+        "vitest-base.config.ts",
+        "vitest-global-setup.ts",
+    ],
+)
+
+ng_application(
+    name = "pinyin-hanzi",
+    srcs = [":srcs"],
+    zonejs = True,
+)
+
+ng_test(
+    name = "test",
+    srcs = [
+        ":srcs",
+        ":vitest_config_files",
+    ],
+    vitest = True,
+    zonejs = True,
+)

--- a/angular/projects/pinyin-hanzi/public/favicon.svg
+++ b/angular/projects/pinyin-hanzi/public/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Pinyin Hanzi favicon">
+  <defs>
+    <linearGradient id="tile" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f6ecdf" />
+      <stop offset="100%" stop-color="#dcb791" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="16" fill="#7d2f1a" />
+  <rect x="6" y="6" width="52" height="52" rx="12" fill="url(#tile)" />
+  <path d="M20 20h24v4H34v6h8v4h-8v10h-4V34h-8v-4h8v-6H20z" fill="#7d2f1a" />
+</svg>

--- a/angular/projects/pinyin-hanzi/src/app/app.config.ts
+++ b/angular/projects/pinyin-hanzi/src/app/app.config.ts
@@ -1,0 +1,16 @@
+import {
+  type ApplicationConfig,
+  provideBrowserGlobalErrorListeners,
+  provideZonelessChangeDetection,
+} from '@angular/core';
+import { provideRouter } from '@angular/router';
+
+import { routes } from './app.routes';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideBrowserGlobalErrorListeners(),
+    provideZonelessChangeDetection(),
+    provideRouter(routes),
+  ],
+};

--- a/angular/projects/pinyin-hanzi/src/app/app.css
+++ b/angular/projects/pinyin-hanzi/src/app/app.css
@@ -1,0 +1,250 @@
+:host {
+  display: block;
+}
+
+.shell {
+  width: min(calc(100% - (var(--space-6) * 2)), var(--size-shell-max));
+  margin-inline: auto;
+  padding-block: var(--space-7);
+  display: grid;
+  gap: var(--space-5);
+}
+
+.panel {
+  background: var(--color-panel);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-panel);
+  padding: var(--space-5);
+}
+
+.hero {
+  background: var(--gradient-hero);
+}
+
+.eyebrow,
+.section-label,
+.candidate-key,
+.note-label,
+.dictionary-key {
+  margin: 0;
+  color: var(--color-accent);
+  font-size: var(--text-sm);
+  font-weight: 700;
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+}
+
+.hero-title,
+.section-title {
+  margin: 0;
+  font-family: var(--font-display);
+  line-height: var(--line-tight);
+}
+
+.hero-title {
+  font-size: var(--text-2xl);
+  max-width: var(--measure-title);
+}
+
+.hero-copy,
+.section-copy,
+.candidate-copy,
+.empty-state,
+.note,
+.dictionary-value,
+.candidate-gloss {
+  margin: 0;
+  color: var(--color-text-muted);
+}
+
+.hero-copy {
+  max-width: var(--measure-copy);
+  font-size: var(--text-lg);
+}
+
+.chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.chip,
+.action-button,
+.dictionary-value {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-pill);
+  border: var(--border-width) solid var(--color-border);
+  padding-block: var(--space-2);
+  padding-inline: var(--space-3);
+  background: var(--color-panel);
+  font-size: var(--text-sm);
+}
+
+.workspace,
+.candidate-grid,
+.dictionary-grid {
+  display: grid;
+  gap: var(--space-4);
+  grid-template-columns: repeat(
+    auto-fit,
+    minmax(min(var(--size-column-min), 100%), 1fr)
+  );
+}
+
+.section-heading,
+.candidate-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: start;
+  gap: var(--space-3);
+}
+
+.section-heading {
+  margin-bottom: var(--space-4);
+}
+
+.field-label {
+  display: block;
+  margin-bottom: var(--space-2);
+  font-weight: 700;
+}
+
+.input-field {
+  width: 100%;
+  min-height: var(--size-field-min-height);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-panel);
+  color: var(--color-text);
+  padding: var(--space-4);
+  resize: vertical;
+  box-shadow: inset 0 0 0 var(--border-width) transparent;
+}
+
+.input-field:focus {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: inset 0 0 0 var(--border-width) var(--color-accent-soft);
+}
+
+.info-stack {
+  margin-top: var(--space-4);
+  display: grid;
+  gap: var(--space-2);
+}
+
+.note {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  border-radius: var(--radius-md);
+  background: var(--color-panel-muted);
+  padding: var(--space-3);
+}
+
+.note--warning {
+  background: var(--color-warning-soft);
+}
+
+.note--danger {
+  background: var(--color-danger-soft);
+}
+
+.plain-output {
+  margin: 0 0 var(--space-4);
+  font-family: var(--font-display);
+  font-size: var(--text-xl);
+}
+
+.ruby-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+
+.ruby-token {
+  min-width: var(--size-ruby-min);
+  display: inline-flex;
+  flex-direction: column-reverse;
+  align-items: center;
+  gap: var(--space-1);
+  border-radius: var(--radius-md);
+  border: var(--border-width) solid var(--color-border);
+  background: var(--color-panel-strong);
+  padding: var(--space-3);
+  box-shadow: var(--shadow-soft);
+}
+
+.ruby-token--remembered {
+  border-color: var(--color-success);
+  background: var(--color-success-soft);
+}
+
+.ruby-token--unknown {
+  border-color: var(--color-danger);
+  background: var(--color-danger-soft);
+}
+
+.ruby-base {
+  color: var(--color-text);
+  font-family: var(--font-display);
+  font-size: var(--text-xl);
+  line-height: var(--line-tight);
+}
+
+.ruby-token rt,
+.fallback-pinyin {
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+  line-height: var(--line-body);
+}
+
+.action-button {
+  cursor: pointer;
+  color: var(--color-accent);
+}
+
+.candidate-card,
+.dictionary-card {
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-panel);
+  padding: var(--space-4);
+}
+
+.candidate-options,
+.dictionary-values {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+}
+
+.candidate-button {
+  min-width: min(100%, var(--size-card-min));
+  display: grid;
+  gap: var(--space-1);
+  justify-items: start;
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-panel);
+  padding: var(--space-3);
+  color: var(--color-text);
+  cursor: pointer;
+  text-align: left;
+}
+
+.candidate-button--active {
+  border-color: var(--color-secondary);
+  background: var(--color-secondary-soft);
+}
+
+.candidate-hanzi {
+  font-family: var(--font-display);
+  font-size: var(--text-xl);
+  line-height: var(--line-tight);
+}

--- a/angular/projects/pinyin-hanzi/src/app/app.html
+++ b/angular/projects/pinyin-hanzi/src/app/app.html
@@ -1,0 +1,175 @@
+<main class="shell">
+  <section class="panel hero">
+    <p class="eyebrow">Client-side pinyin → hanzi</p>
+    <h1 class="hero-title">Compose hanzi with local remembered choices.</h1>
+    <p class="hero-copy">
+      Enter space-separated pinyin. Tone marks and number suffixes normalize
+      automatically, ambiguous syllables expose candidates, and your picks stay
+      in this browser until you clear them.
+    </p>
+    <div class="chip-row" aria-label="Feature highlights">
+      <span class="chip">Standalone Angular</span>
+      <span class="chip">Embedded dictionary</span>
+      <span class="chip">Ruby pronunciation</span>
+      <span class="chip">Remembered selections</span>
+    </div>
+  </section>
+
+  <section class="workspace">
+    <article class="panel">
+      <div class="section-heading">
+        <div>
+          <p class="section-label">Input</p>
+          <h2 class="section-title">Pinyin workspace</h2>
+        </div>
+      </div>
+
+      <label class="field-label" for="pinyin-input"
+        >Space-separated pinyin</label
+      >
+      <textarea
+        id="pinyin-input"
+        class="input-field"
+        data-testid="pinyin-input"
+        spellcheck="false"
+        autocapitalize="off"
+        autocomplete="off"
+        autocorrect="off"
+        [value]="inputValue()"
+        (input)="updateInput(pinyinInput.value)"
+        #pinyinInput
+      ></textarea>
+
+      <div class="info-stack">
+        <p class="note">
+          <span class="note-label">Normalized</span>
+          <code>{{ parsedInput().normalizedInput || '—' }}</code>
+        </p>
+
+        @if (parsedInput().invalidTokens.length > 0) {
+        <p class="note note--warning">
+          <span class="note-label">Ignored tokens</span>
+          {{ parsedInput().invalidTokens.join(', ') }}
+        </p>
+        } @if (composition().unknownKeys.length > 0) {
+        <p class="note note--danger">
+          <span class="note-label">Missing from dictionary</span>
+          {{ composition().unknownKeys.join(', ') }}
+        </p>
+        }
+      </div>
+    </article>
+
+    <article class="panel">
+      <div class="section-heading">
+        <div>
+          <p class="section-label">Output</p>
+          <h2 class="section-title">Ruby rendering</h2>
+        </div>
+
+        @if (rememberedChoiceCount() > 0) {
+        <button
+          type="button"
+          class="action-button"
+          data-testid="clear-memory"
+          (click)="clearRememberedChoices()"
+        >
+          {{ rememberedChoiceLabel() }}
+        </button>
+        }
+      </div>
+
+      @if (composition().segments.length > 0) {
+      <p class="plain-output" data-testid="plain-output">
+        {{ composition().selectedText }}
+      </p>
+      <div class="ruby-strip" aria-live="polite" data-testid="rendered-output">
+        @for (segment of composition().segments; track segment.key + '-' +
+        $index) { @if (segment.isKnown && segment.selectedHanzi) {
+        <ruby
+          class="ruby-token"
+          [class.ruby-token--remembered]="segment.isRemembered"
+        >
+          <span class="ruby-base">{{ segment.selectedHanzi }}</span>
+          <rt>{{ segment.pinyin }}</rt>
+        </ruby>
+        } @else {
+        <span class="ruby-token ruby-token--unknown">
+          <span class="ruby-base">?</span>
+          <span class="fallback-pinyin">{{ segment.pinyin }}</span>
+        </span>
+        } }
+      </div>
+      } @else {
+      <p class="empty-state">Type pinyin above to see composed hanzi here.</p>
+      }
+    </article>
+  </section>
+
+  @if (ambiguousSegments().length > 0) {
+  <section class="panel">
+    <div class="section-heading">
+      <div>
+        <p class="section-label">Disambiguation</p>
+        <h2 class="section-title">Choose how ambiguous pinyin should render</h2>
+      </div>
+      <p class="section-copy">Selections persist per normalized pinyin key.</p>
+    </div>
+
+    <div class="candidate-grid">
+      @for (segment of ambiguousSegments(); track segment.key + '-' + $index) {
+      <article class="candidate-card">
+        <div class="candidate-heading">
+          <div>
+            <p class="candidate-key">{{ segment.key }}</p>
+            <p class="candidate-copy">Tap one candidate to remember it.</p>
+          </div>
+        </div>
+
+        <div class="candidate-options">
+          @for (option of segment.options; track option.hanzi) {
+          <button
+            type="button"
+            class="candidate-button"
+            data-testid="candidate-choice"
+            [attr.data-key]="segment.key"
+            [attr.data-hanzi]="option.hanzi"
+            [class.candidate-button--active]="segment.selectedHanzi === option.hanzi"
+            (click)="rememberChoice(segment.key, option.hanzi)"
+          >
+            <span class="candidate-hanzi">{{ option.hanzi }}</span>
+            <span class="candidate-gloss">{{ option.gloss }}</span>
+          </button>
+          }
+        </div>
+      </article>
+      }
+    </div>
+  </section>
+  }
+
+  <section class="panel">
+    <div class="section-heading">
+      <div>
+        <p class="section-label">Embedded dictionary</p>
+        <h2 class="section-title">Built-in local coverage</h2>
+      </div>
+      <p class="section-copy">
+        Small by design so the app stays self-contained.
+      </p>
+    </div>
+
+    <div class="dictionary-grid">
+      @for (entry of dictionaryEntries; track entry.key) {
+      <article class="dictionary-card">
+        <p class="dictionary-key">{{ entry.key }}</p>
+        <div class="dictionary-values">
+          @for (option of entry.options; track option.hanzi) {
+          <span class="dictionary-value">{{ option.hanzi }}</span>
+          }
+        </div>
+      </article>
+      }
+    </div>
+  </section>
+</main>

--- a/angular/projects/pinyin-hanzi/src/app/app.routes.ts
+++ b/angular/projects/pinyin-hanzi/src/app/app.routes.ts
@@ -1,0 +1,3 @@
+import type { Routes } from '@angular/router';
+
+export const routes: Routes = [];

--- a/angular/projects/pinyin-hanzi/src/app/app.spec.ts
+++ b/angular/projects/pinyin-hanzi/src/app/app.spec.ts
@@ -1,0 +1,75 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { App } from './app';
+import {
+  BROWSER_STORAGE,
+  loadRememberedChoices,
+  type StorageLike,
+} from './remembered-choices.store';
+
+class FakeStorage implements StorageLike {
+  private readonly values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+}
+
+describe('App', () => {
+  let storage: FakeStorage;
+
+  beforeEach(async () => {
+    storage = new FakeStorage();
+
+    await TestBed.configureTestingModule({
+      imports: [App],
+      providers: [
+        provideZonelessChangeDetection(),
+        {
+          provide: BROWSER_STORAGE,
+          useValue: storage,
+        },
+      ],
+    }).compileComponents();
+  });
+
+  it('creates the app', () => {
+    const fixture = TestBed.createComponent(App);
+
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('updates the rendered output and remembered storage when a choice is selected', () => {
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement as HTMLElement;
+    const output = host.querySelector('[data-testid="plain-output"]');
+    expect(output?.textContent?.trim()).toBe('你好吗');
+
+    const motherButton = host.querySelector(
+      '[data-testid="candidate-choice"][data-key="ma"][data-hanzi="妈"]',
+    );
+    motherButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    fixture.detectChanges();
+
+    expect(output?.textContent?.trim()).toBe('你好妈');
+    expect(loadRememberedChoices(storage)).toEqual({ ma: '妈' });
+
+    const clearButton = host.querySelector('[data-testid="clear-memory"]');
+    clearButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    fixture.detectChanges();
+
+    expect(output?.textContent?.trim()).toBe('你好吗');
+    expect(loadRememberedChoices(storage)).toEqual({});
+  });
+});

--- a/angular/projects/pinyin-hanzi/src/app/app.ts
+++ b/angular/projects/pinyin-hanzi/src/app/app.ts
@@ -1,0 +1,62 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+
+import { composePinyinTokens } from './pinyin-composer';
+import type { ComposedSegment } from './pinyin-composer';
+import { PINYIN_DICTIONARY } from './pinyin-dictionary';
+import { parsePinyinInput } from './pinyin-parser';
+import { RememberedChoicesStore } from './remembered-choices.store';
+
+@Component({
+  selector: 'app-root',
+  imports: [],
+  templateUrl: './app.html',
+  styleUrl: './app.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class App {
+  private readonly rememberedChoicesStore = inject(RememberedChoicesStore);
+
+  protected readonly inputValue = signal('ni hao ma');
+  protected readonly dictionaryEntries = PINYIN_DICTIONARY;
+
+  protected readonly parsedInput = computed(() =>
+    parsePinyinInput(this.inputValue()),
+  );
+  protected readonly composition = computed(() =>
+    composePinyinTokens(
+      this.parsedInput().tokens,
+      this.rememberedChoicesStore.choices(),
+    ),
+  );
+  protected readonly ambiguousSegments = computed(() =>
+    this.composition().segments.filter(
+      (segment): segment is ComposedSegment => segment.isAmbiguous,
+    ),
+  );
+  protected readonly rememberedChoiceCount = computed(
+    () => Object.keys(this.rememberedChoicesStore.choices()).length,
+  );
+  protected readonly rememberedChoiceLabel = computed(() => {
+    const count = this.rememberedChoiceCount();
+
+    return `Clear ${count} remembered choice${count === 1 ? '' : 's'}`;
+  });
+
+  protected updateInput(value: string): void {
+    this.inputValue.set(value);
+  }
+
+  protected rememberChoice(segmentKey: string, hanzi: string): void {
+    this.rememberedChoicesStore.rememberChoice(segmentKey, hanzi);
+  }
+
+  protected clearRememberedChoices(): void {
+    this.rememberedChoicesStore.clear();
+  }
+}

--- a/angular/projects/pinyin-hanzi/src/app/pinyin-composer.spec.ts
+++ b/angular/projects/pinyin-hanzi/src/app/pinyin-composer.spec.ts
@@ -1,0 +1,25 @@
+import { composePinyinTokens } from './pinyin-composer';
+
+describe('composePinyinTokens', () => {
+  it('prefers the longest dictionary entry and applies remembered choices', () => {
+    const composition = composePinyinTokens(
+      ['wo', 'shi', 'zhong', 'guo', 'ren'],
+      { shi: '时' },
+    );
+
+    expect(composition.selectedText).toBe('我时中国人');
+    expect(composition.unknownKeys).toEqual([]);
+    expect(
+      composition.segments.map((segment) => segment.selectedHanzi),
+    ).toEqual(['我', '时', '中国', '人']);
+    expect(composition.segments[1]?.isRemembered).toBe(true);
+    expect(composition.segments[2]?.pinyin).toBe('zhong guo');
+  });
+
+  it('surfaces unknown tokens when no dictionary match exists', () => {
+    const composition = composePinyinTokens(['ni', 'mystery'], {});
+
+    expect(composition.unknownKeys).toEqual(['mystery']);
+    expect(composition.selectedText).toBe('你mystery');
+  });
+});

--- a/angular/projects/pinyin-hanzi/src/app/pinyin-composer.ts
+++ b/angular/projects/pinyin-hanzi/src/app/pinyin-composer.ts
@@ -1,0 +1,118 @@
+import {
+  MAX_PINYIN_ENTRY_LENGTH,
+  PINYIN_DICTIONARY_BY_KEY,
+} from './pinyin-dictionary';
+import type {
+  HanziOption,
+  PinyinDictionaryEntry,
+} from './pinyin-dictionary';
+import type { RememberedChoices } from './remembered-choices.store';
+
+export interface ComposedSegment {
+  readonly key: string;
+  readonly pinyin: string;
+  readonly options: readonly HanziOption[];
+  readonly selectedHanzi: string | null;
+  readonly isAmbiguous: boolean;
+  readonly isKnown: boolean;
+  readonly isRemembered: boolean;
+}
+
+export interface CompositionResult {
+  readonly segments: readonly ComposedSegment[];
+  readonly unknownKeys: readonly string[];
+  readonly selectedText: string;
+}
+
+function pickRememberedOption(
+  entry: PinyinDictionaryEntry,
+  rememberedChoices: RememberedChoices,
+): { selectedHanzi: string; isRemembered: boolean } {
+  const rememberedHanzi = rememberedChoices[entry.key];
+  const selectedOption = entry.options.find(
+    (option) => option.hanzi === rememberedHanzi,
+  );
+
+  if (selectedOption) {
+    return {
+      selectedHanzi: selectedOption.hanzi,
+      isRemembered: true,
+    };
+  }
+
+  return {
+    selectedHanzi: entry.options[0]?.hanzi ?? '',
+    isRemembered: false,
+  };
+}
+
+export function composePinyinTokens(
+  tokens: readonly string[],
+  rememberedChoices: RememberedChoices,
+): CompositionResult {
+  const segments: ComposedSegment[] = [];
+  const unknownKeys: string[] = [];
+  const selectedText: string[] = [];
+
+  let index = 0;
+
+  while (index < tokens.length) {
+    const remainingLength = Math.min(
+      MAX_PINYIN_ENTRY_LENGTH,
+      tokens.length - index,
+    );
+
+    let matchedEntry: PinyinDictionaryEntry | undefined;
+
+    for (let length = remainingLength; length > 0; length -= 1) {
+      const candidateKey = tokens.slice(index, index + length).join(' ');
+      const entry = PINYIN_DICTIONARY_BY_KEY.get(candidateKey);
+
+      if (entry) {
+        matchedEntry = entry;
+        break;
+      }
+    }
+
+    if (!matchedEntry) {
+      const unknownKey = tokens[index] ?? '';
+
+      segments.push({
+        key: unknownKey,
+        pinyin: unknownKey,
+        options: [],
+        selectedHanzi: null,
+        isAmbiguous: false,
+        isKnown: false,
+        isRemembered: false,
+      });
+      unknownKeys.push(unknownKey);
+      selectedText.push(unknownKey);
+      index += 1;
+      continue;
+    }
+
+    const selectedOption = pickRememberedOption(
+      matchedEntry,
+      rememberedChoices,
+    );
+
+    segments.push({
+      key: matchedEntry.key,
+      pinyin: matchedEntry.key,
+      options: matchedEntry.options,
+      selectedHanzi: selectedOption.selectedHanzi,
+      isAmbiguous: matchedEntry.options.length > 1,
+      isKnown: true,
+      isRemembered: selectedOption.isRemembered,
+    });
+    selectedText.push(selectedOption.selectedHanzi);
+    index += matchedEntry.syllables.length;
+  }
+
+  return {
+    segments,
+    unknownKeys,
+    selectedText: selectedText.join(''),
+  };
+}

--- a/angular/projects/pinyin-hanzi/src/app/pinyin-dictionary.ts
+++ b/angular/projects/pinyin-hanzi/src/app/pinyin-dictionary.ts
@@ -1,0 +1,54 @@
+export interface HanziOption {
+  readonly hanzi: string;
+  readonly gloss: string;
+}
+
+export interface PinyinDictionaryEntry {
+  readonly key: string;
+  readonly syllables: readonly string[];
+  readonly options: readonly HanziOption[];
+}
+
+function defineEntry(
+  key: string,
+  options: readonly HanziOption[],
+): PinyinDictionaryEntry {
+  return {
+    key,
+    syllables: key.split(' '),
+    options,
+  };
+}
+
+export const PINYIN_DICTIONARY: readonly PinyinDictionaryEntry[] = [
+  defineEntry('ni', [{ hanzi: '你', gloss: 'you' }]),
+  defineEntry('hao', [{ hanzi: '好', gloss: 'good' }]),
+  defineEntry('ni hao', [{ hanzi: '你好', gloss: 'hello' }]),
+  defineEntry('ma', [
+    { hanzi: '吗', gloss: 'question particle' },
+    { hanzi: '妈', gloss: 'mother' },
+    { hanzi: '马', gloss: 'horse' },
+  ]),
+  defineEntry('wo', [{ hanzi: '我', gloss: 'I / me' }]),
+  defineEntry('shi', [
+    { hanzi: '是', gloss: 'to be' },
+    { hanzi: '时', gloss: 'time' },
+    { hanzi: '事', gloss: 'matter' },
+  ]),
+  defineEntry('zhong guo', [{ hanzi: '中国', gloss: 'China' }]),
+  defineEntry('ren', [{ hanzi: '人', gloss: 'person' }]),
+  defineEntry('xue sheng', [{ hanzi: '学生', gloss: 'student' }]),
+  defineEntry('peng you', [{ hanzi: '朋友', gloss: 'friend' }]),
+  defineEntry('ai', [{ hanzi: '爱', gloss: 'love' }]),
+  defineEntry('he cha', [{ hanzi: '喝茶', gloss: 'drink tea' }]),
+  defineEntry('chi fan', [{ hanzi: '吃饭', gloss: 'eat a meal' }]),
+];
+
+export const PINYIN_DICTIONARY_BY_KEY = new Map(
+  PINYIN_DICTIONARY.map((entry) => [entry.key, entry]),
+);
+
+export const MAX_PINYIN_ENTRY_LENGTH = PINYIN_DICTIONARY.reduce(
+  (maxLength, entry) => Math.max(maxLength, entry.syllables.length),
+  1,
+);

--- a/angular/projects/pinyin-hanzi/src/app/pinyin-parser.spec.ts
+++ b/angular/projects/pinyin-hanzi/src/app/pinyin-parser.spec.ts
@@ -1,0 +1,19 @@
+import { parsePinyinInput } from './pinyin-parser';
+
+describe('parsePinyinInput', () => {
+  it('normalizes spacing, tone marks, and tone numbers', () => {
+    expect(parsePinyinInput('  Nǐ   hao3   ma5 ')).toEqual({
+      tokens: ['ni', 'hao', 'ma'],
+      normalizedInput: 'ni hao ma',
+      invalidTokens: [],
+    });
+  });
+
+  it('keeps invalid tokens separate from valid ones', () => {
+    expect(parsePinyinInput('wo @@@ pengyou!')).toEqual({
+      tokens: ['wo', 'pengyou'],
+      normalizedInput: 'wo pengyou',
+      invalidTokens: ['@@@'],
+    });
+  });
+});

--- a/angular/projects/pinyin-hanzi/src/app/pinyin-parser.ts
+++ b/angular/projects/pinyin-hanzi/src/app/pinyin-parser.ts
@@ -1,0 +1,75 @@
+const DIACRITIC_TO_BASE: Record<string, string> = {
+  ā: 'a',
+  á: 'a',
+  ǎ: 'a',
+  à: 'a',
+  ē: 'e',
+  é: 'e',
+  ě: 'e',
+  è: 'e',
+  ī: 'i',
+  í: 'i',
+  ǐ: 'i',
+  ì: 'i',
+  ō: 'o',
+  ó: 'o',
+  ǒ: 'o',
+  ò: 'o',
+  ū: 'u',
+  ú: 'u',
+  ǔ: 'u',
+  ù: 'u',
+  ǖ: 'ü',
+  ǘ: 'ü',
+  ǚ: 'ü',
+  ǜ: 'ü',
+  ü: 'ü',
+  ń: 'n',
+  ň: 'n',
+  ǹ: 'n',
+  ḿ: 'm',
+};
+
+export interface ParsedPinyinInput {
+  readonly tokens: readonly string[];
+  readonly normalizedInput: string;
+  readonly invalidTokens: readonly string[];
+}
+
+export function normalizePinyinToken(token: string): string {
+  if (!token.trim()) {
+    return '';
+  }
+
+  let normalized = token.trim().toLowerCase();
+  normalized = normalized.replace(/u:/g, 'ü').replace(/v/g, 'ü');
+  normalized = Array.from(normalized, (character) => {
+    return DIACRITIC_TO_BASE[character] ?? character;
+  }).join('');
+  normalized = normalized.replace(/[1-5]/g, '');
+  normalized = normalized.replace(/'/g, '');
+  normalized = normalized.replace(/[^a-zü]/g, '');
+
+  return /^[a-zü]+$/u.test(normalized) ? normalized : '';
+}
+
+export function parsePinyinInput(input: string): ParsedPinyinInput {
+  const tokens: string[] = [];
+  const invalidTokens: string[] = [];
+
+  for (const rawToken of input.split(/\s+/u).filter(Boolean)) {
+    const normalizedToken = normalizePinyinToken(rawToken);
+
+    if (normalizedToken) {
+      tokens.push(normalizedToken);
+    } else {
+      invalidTokens.push(rawToken);
+    }
+  }
+
+  return {
+    tokens,
+    normalizedInput: tokens.join(' '),
+    invalidTokens,
+  };
+}

--- a/angular/projects/pinyin-hanzi/src/app/remembered-choices.store.spec.ts
+++ b/angular/projects/pinyin-hanzi/src/app/remembered-choices.store.spec.ts
@@ -1,0 +1,40 @@
+import {
+  loadRememberedChoices,
+  REMEMBERED_CHOICES_STORAGE_KEY,
+  saveRememberedChoices,
+} from './remembered-choices.store';
+import type { StorageLike } from './remembered-choices.store';
+
+class FakeStorage implements StorageLike {
+  private readonly values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+}
+
+describe('remembered choice persistence', () => {
+  it('round-trips remembered choices through storage', () => {
+    const storage = new FakeStorage();
+
+    saveRememberedChoices(storage, { ma: '妈', shi: '事' });
+
+    expect(loadRememberedChoices(storage)).toEqual({ ma: '妈', shi: '事' });
+  });
+
+  it('treats invalid stored json as empty state', () => {
+    const storage = new FakeStorage();
+
+    storage.setItem(REMEMBERED_CHOICES_STORAGE_KEY, '{not-json');
+
+    expect(loadRememberedChoices(storage)).toEqual({});
+  });
+});

--- a/angular/projects/pinyin-hanzi/src/app/remembered-choices.store.ts
+++ b/angular/projects/pinyin-hanzi/src/app/remembered-choices.store.ts
@@ -1,0 +1,114 @@
+import { inject, Injectable, InjectionToken, signal } from '@angular/core';
+
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+export type RememberedChoices = Record<string, string>;
+
+export const REMEMBERED_CHOICES_STORAGE_KEY = 'pinyin-hanzi.remembered-choices';
+
+class InMemoryStorage implements StorageLike {
+  private readonly values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function createStorage(): StorageLike {
+  try {
+    return globalThis.localStorage;
+  } catch {
+    return new InMemoryStorage();
+  }
+}
+
+export const BROWSER_STORAGE = new InjectionToken<StorageLike>(
+  'BROWSER_STORAGE',
+  {
+    providedIn: 'root',
+    factory: createStorage,
+  },
+);
+
+export function loadRememberedChoices(storage: StorageLike): RememberedChoices {
+  const rawValue = storage.getItem(REMEMBERED_CHOICES_STORAGE_KEY);
+
+  if (!rawValue) {
+    return {};
+  }
+
+  try {
+    const parsedValue: unknown = JSON.parse(rawValue);
+
+    if (!isRecord(parsedValue)) {
+      return {};
+    }
+
+    const rememberedChoices: RememberedChoices = {};
+
+    for (const [key, value] of Object.entries(parsedValue)) {
+      if (key.length > 0 && typeof value === 'string') {
+        rememberedChoices[key] = value;
+      }
+    }
+
+    return rememberedChoices;
+  } catch {
+    return {};
+  }
+}
+
+export function saveRememberedChoices(
+  storage: StorageLike,
+  rememberedChoices: RememberedChoices,
+): void {
+  if (Object.keys(rememberedChoices).length === 0) {
+    storage.removeItem(REMEMBERED_CHOICES_STORAGE_KEY);
+    return;
+  }
+
+  storage.setItem(
+    REMEMBERED_CHOICES_STORAGE_KEY,
+    JSON.stringify(rememberedChoices),
+  );
+}
+
+@Injectable({ providedIn: 'root' })
+export class RememberedChoicesStore {
+  private readonly storage = inject(BROWSER_STORAGE);
+
+  readonly choices = signal<RememberedChoices>(
+    loadRememberedChoices(this.storage),
+  );
+
+  rememberChoice(key: string, hanzi: string): void {
+    const nextChoices = {
+      ...this.choices(),
+      [key]: hanzi,
+    };
+
+    saveRememberedChoices(this.storage, nextChoices);
+    this.choices.set(nextChoices);
+  }
+
+  clear(): void {
+    saveRememberedChoices(this.storage, {});
+    this.choices.set({});
+  }
+}

--- a/angular/projects/pinyin-hanzi/src/index.html
+++ b/angular/projects/pinyin-hanzi/src/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Pinyin Hanzi</title>
+    <base href="/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="Client-side pinyin to hanzi composition with remembered choices and ruby pronunciation."
+    />
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
+  </head>
+  <body>
+    <app-root></app-root>
+  </body>
+</html>

--- a/angular/projects/pinyin-hanzi/src/main.ts
+++ b/angular/projects/pinyin-hanzi/src/main.ts
@@ -1,0 +1,6 @@
+import { bootstrapApplication } from '@angular/platform-browser';
+
+import { App } from './app/app';
+import { appConfig } from './app/app.config';
+
+bootstrapApplication(App, appConfig).catch((err) => console.error(err));

--- a/angular/projects/pinyin-hanzi/src/styles.css
+++ b/angular/projects/pinyin-hanzi/src/styles.css
@@ -1,0 +1,92 @@
+:root {
+  color-scheme: light;
+  --font-body: "Avenir Next", "Segoe UI", sans-serif;
+  --font-display: "Palatino Linotype", "Book Antiqua", Georgia, serif;
+  --font-mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.5rem;
+  --space-6: 2rem;
+  --space-7: 3rem;
+  --space-8: 4rem;
+
+  --radius-sm: 0.75rem;
+  --radius-md: 1rem;
+  --radius-lg: 1.5rem;
+  --radius-pill: 999px;
+
+  --size-shell-max: 76rem;
+  --size-column-min: 20rem;
+  --size-field-min-height: 10rem;
+  --size-ruby-min: 5rem;
+  --size-card-min: 14rem;
+  --border-width: 1px;
+  --measure-title: 16ch;
+  --measure-copy: 44rem;
+  --tracking-wide: 0.08em;
+
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-md: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.5rem;
+  --text-2xl: clamp(2.25rem, 5vw, 4rem);
+  --line-tight: 1.1;
+  --line-body: 1.6;
+
+  --color-canvas: #f4ede4;
+  --color-panel: #fffaf3;
+  --color-panel-strong: #f0e1d0;
+  --color-panel-muted: #ede3d7;
+  --color-border: #d0bcaa;
+  --color-border-strong: #b58b67;
+  --color-text: #2b2119;
+  --color-text-muted: #6d5846;
+  --color-text-inverse: #fffaf3;
+  --color-accent: #8b3a22;
+  --color-accent-strong: #632819;
+  --color-accent-soft: #f6e0d6;
+  --color-secondary: #2b6078;
+  --color-secondary-soft: #daeaf2;
+  --color-success: #2f7757;
+  --color-success-soft: #dcefe5;
+  --color-warning: #9f6d12;
+  --color-warning-soft: #f5ead4;
+  --color-danger: #aa463d;
+  --color-danger-soft: #f5ddda;
+  --gradient-page: radial-gradient(circle at top, #fff4e3 0%, #f4ede4 52%);
+  --gradient-hero: linear-gradient(135deg, #fffaf3 0%, #f1dfc8 100%);
+  --shadow-panel: 0 1.5rem 4rem rgb(79 53 28 / 0.12);
+  --shadow-soft: 0 0.75rem 2rem rgb(79 53 28 / 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  background: var(--gradient-page);
+  color: var(--color-text);
+  font-family: var(--font-body);
+  font-size: var(--text-md);
+  line-height: var(--line-body);
+}
+
+button,
+textarea,
+input {
+  font: inherit;
+}
+
+code {
+  font-family: var(--font-mono);
+}

--- a/angular/projects/pinyin-hanzi/tsconfig.app.json
+++ b/angular/projects/pinyin-hanzi/tsconfig.app.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../out-tsc/app",
+    "types": []
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts"]
+}

--- a/angular/projects/pinyin-hanzi/tsconfig.spec.json
+++ b/angular/projects/pinyin-hanzi/tsconfig.spec.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../out-tsc/spec",
+    "types": ["vitest/globals"]
+  },
+  "include": ["src/**/*.d.ts", "src/**/*.spec.ts"]
+}

--- a/angular/projects/pinyin-hanzi/vitest-base.config.ts
+++ b/angular/projects/pinyin-hanzi/vitest-base.config.ts
@@ -1,0 +1,15 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const reportsDirectory = join(__dirname, '.vitest-coverage');
+
+export default defineConfig({
+  test: {
+    coverage: {
+      reportsDirectory,
+    },
+    globalSetup: [join(__dirname, 'vitest-global-setup.ts')],
+  },
+});

--- a/angular/projects/pinyin-hanzi/vitest-global-setup.ts
+++ b/angular/projects/pinyin-hanzi/vitest-global-setup.ts
@@ -1,0 +1,35 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export async function teardown() {
+  const coverageOutputFile = process.env.COVERAGE_OUTPUT_FILE;
+
+  if (!coverageOutputFile) {
+    return;
+  }
+
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const lcovSource = join(__dirname, '.vitest-coverage', 'lcov.info');
+
+  if (!existsSync(lcovSource)) {
+    process.stderr.write(
+      `[vitest-coverage] lcov file not found at: ${lcovSource}\n`,
+    );
+    return;
+  }
+
+  const content = readFileSync(lcovSource, 'utf-8');
+  const fixedContent = content.replace(/^(SF:)(?!angular\/)/gm, '$1angular/');
+
+  mkdirSync(dirname(coverageOutputFile), { recursive: true });
+  writeFileSync(coverageOutputFile, fixedContent, 'utf-8');
+
+  const sourceFileCount = fixedContent
+    .split('\n')
+    .filter((line) => line.startsWith('SF:')).length;
+
+  process.stderr.write(
+    `[vitest-coverage] Wrote ${sourceFileCount} SF: entries to: ${coverageOutputFile}\n`,
+  );
+}

--- a/angular/tsconfig.json
+++ b/angular/tsconfig.json
@@ -30,6 +30,12 @@
       "path": "./projects/nicknamer/tsconfig.spec.json"
     },
     {
+      "path": "./projects/pinyin-hanzi/tsconfig.app.json"
+    },
+    {
+      "path": "./projects/pinyin-hanzi/tsconfig.spec.json"
+    },
+    {
       "path": "./projects/mindreadr/tsconfig.app.json"
     },
     {


### PR DESCRIPTION
## Summary
- add a new `angular/projects/pinyin-hanzi` Angular app wired into the Bazel workspace
- implement client-side pinyin parsing, hanzi selection memory, and ruby pronunciation rendering
- cover the core parsing, composition, persistence, and UI behavior with focused Vitest specs

## Verification
- bazel run gazelle
- bazel test //angular/projects/pinyin-hanzi:test
- bazel build //angular/projects/pinyin-hanzi:pinyin-hanzi
- bazel build //...