### PR TITLE
build: migrate aspect tooling to LowkeyLab nix package

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@616559265b40713947b9c190a8ff4b507b5df49b
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,6 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
       - uses: bazel-contrib/setup-bazel@d68576867819dfdec2cf9586a68795f81461da3e
         with:
           # Avoid downloading Bazel every time.
@@ -32,12 +37,10 @@ jobs:
           username: ${{ vars.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - uses: browser-actions/setup-chrome@b94431e051d1c52dcbe9a7092a4f10f827795416
-      - name: Install Aspect CLI
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Install Aspect from flake
         run: |
-          gh release download v2026.4.2 --repo aspect-build/aspect-cli --pattern 'aspect-cli-x86_64-unknown-linux-musl' --output /usr/local/bin/aspect
-          chmod +x /usr/local/bin/aspect
+          nix build .#aspect
+          install -Dm755 ./result/bin/aspect /usr/local/bin/aspect
       - name: Run Bazel Lints
         run: |
           aspect lint //...

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes
+      - name: Configure Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39
       - uses: bazel-contrib/setup-bazel@d68576867819dfdec2cf9586a68795f81461da3e
         with:
           # Avoid downloading Bazel every time.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Development Setup
 
-This repo uses a **Nix flake** for reproducible dev tooling. The flake provides `bazelisk`, `bazel`, `aspect`, `buildifier`, `prettier`, `pnpm`, `go`, `java`, `starpls`, `pre-commit`, and Bazel-backed `format`/`coverage` commands.
+This repo uses a **Nix flake** for reproducible dev tooling. The flake provides `bazelisk`, `bazel`, `aspect`, `buildifier`, `prettier`, `pnpm`, `go`, `java`, `starpls`, `pre-commit`, and Bazel-backed `format`/`coverage` commands. For now, the flake assumes `x86_64-linux`, and `aspect` comes from `LowkeyLab/nix`.
 
 ### Prerequisites
 
@@ -142,7 +142,7 @@ Angular 21 projects live in `angular/projects/` (mindreadr, nicknamer, predix, t
 
 ### CI/CD
 
-- **run-tests.yml**: on push/PR to main — runs `aspect lint //...` then `aspect test //...` with BuildBuddy remote cache
+- **run-tests.yml**: on push/PR to main — installs `aspect` from `.#aspect`, then runs `aspect lint //...` and `aspect test //...` with BuildBuddy remote cache
 - **deploy.yml**: after tests pass on main — builds optimized and pushes all OCI images to GHCR
 
 ## Code Conventions

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Windows (PowerShell):
 choco install bazelisk
 ```
 
-If you use Nix + direnv, `direnv allow` enters a flake shell that provides the common local CLI tools (`bazel`, `bazelisk`, `aspect`, `buildifier`, `prettier`, `pnpm`, `go`, `java`, `starpls`, `pre-commit`, plus `format`/`coverage` commands). Bazel still owns the build, test, format, and coverage behavior for the repo.
+If you use Nix + direnv, `direnv allow` enters a flake shell that provides the common local CLI tools (`bazel`, `bazelisk`, `aspect`, `buildifier`, `prettier`, `pnpm`, `go`, `java`, `starpls`, `pre-commit`, plus `format`/`coverage` commands). For now, the flake assumes `x86_64-linux`, and `aspect` comes from `LowkeyLab/nix`. Bazel still owns the build, test, format, and coverage behavior for the repo.
 
 ## Quick Start
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,68 @@
 {
   "nodes": {
+    "aspect-cli-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1769121247,
+        "narHash": "sha256-N3y+MS19aPI9BQwvrrkrt5u9x9/WE28syStfOLe4aPM=",
+        "owner": "aspect-build",
+        "repo": "aspect-cli",
+        "rev": "2a995acc48c4035b9195fbc8030473e2073b5265",
+        "type": "github"
+      },
+      "original": {
+        "owner": "aspect-build",
+        "ref": "v2026.4.2",
+        "repo": "aspect-cli",
+        "type": "github"
+      }
+    },
+    "blueprint": {
+      "inputs": {
+        "nixpkgs": [
+          "lowkeylab-nix",
+          "nixpkgs"
+        ],
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1776249299,
+        "narHash": "sha256-Dt9t1TGRmJFc0xVYhttNBD6QsAgHOHCArqGa0AyjrJY=",
+        "owner": "numtide",
+        "repo": "blueprint",
+        "rev": "56131e8628f173d24a27f6d27c0215eff57e40dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "blueprint",
+        "type": "github"
+      }
+    },
+    "lowkeylab-nix": {
+      "inputs": {
+        "aspect-cli-src": [
+          "aspect-cli-src"
+        ],
+        "blueprint": "blueprint",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777152945,
+        "narHash": "sha256-iw9rNxjnFPcDh5FGRm/yUUcTF6tlu1aOPx72/s5mO64=",
+        "owner": "LowkeyLab",
+        "repo": "nix",
+        "rev": "4e66cbd8bc26c3ff05ec3cfd3600b7e4f188e7f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "LowkeyLab",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1775126147,
@@ -18,7 +81,24 @@
     },
     "root": {
       "inputs": {
+        "aspect-cli-src": "aspect-cli-src",
+        "lowkeylab-nix": "lowkeylab-nix",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
         system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
-          aspect = lowkeylab-nix.packages.x86_64-linux.aspect;
+          aspect = lowkeylab-nix.packages.${system}.aspect;
         in
         {
           inherit pkgs aspect;

--- a/flake.nix
+++ b/flake.nix
@@ -3,61 +3,49 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    aspect-cli-src = {
+      url = "github:aspect-build/aspect-cli/v2026.4.2";
+      flake = false;
+    };
+    lowkeylab-nix = {
+      url = "github:LowkeyLab/nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.aspect-cli-src.follows = "aspect-cli-src";
+    };
   };
 
   outputs =
-    { nixpkgs, ... }:
+    { nixpkgs, lowkeylab-nix, ... }:
     let
       supportedSystems = [
         "x86_64-linux"
-        "aarch64-linux"
-        "x86_64-darwin"
-        "aarch64-darwin"
       ];
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
-      binaryReleases = {
-        aspect = {
-          version = "2026.4.2";
-          binaries = {
-            "aarch64-linux" = {
-              url = "https://github.com/aspect-build/aspect-cli/releases/download/v2026.4.2/aspect-cli-aarch64-unknown-linux-musl";
-              sha256 = "a1f5735753a0417740ab13f69c3591c7e5ba08499e3654f8c8af031008ae8fb6";
-            };
-            "x86_64-darwin" = {
-              url = "https://github.com/aspect-build/aspect-cli/releases/download/v2026.4.2/aspect-cli-x86_64-apple-darwin";
-              sha256 = "51173ac14cad639e281ed467b6db789b0a14d053b74cb5436d1b8b56e230d275";
-            };
-            "x86_64-linux" = {
-              url = "https://github.com/aspect-build/aspect-cli/releases/download/v2026.4.2/aspect-cli-x86_64-unknown-linux-musl";
-              sha256 = "58057a7bfb94838749cbb3fedc015baeefa1887caf00e1ed4dd5eb8ef00c6cef";
-            };
-            "aarch64-darwin" = {
-              url = "https://github.com/aspect-build/aspect-cli/releases/download/v2026.4.2/aspect-cli-aarch64-apple-darwin";
-              sha256 = "5cae50dcd8a2548ec433833a80d8e0ef3d41965c3673db700f8bbc52e5f15600";
-            };
-          };
-        };
-      };
-    in
-    {
-      devShells = forAllSystems (
+      mkPackagesForSystem =
         system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
-          mkFetchedBinary =
-            { name, version, url, sha256 }:
-            pkgs.stdenvNoCC.mkDerivation {
-              pname = name;
-              inherit version;
-              src = pkgs.fetchurl {
-                inherit url sha256;
-              };
-              dontUnpack = true;
-              installPhase = ''
-                install -Dm755 "$src" "$out/bin/${name}"
-              '';
-            };
-          aspectBinary = binaryReleases.aspect.binaries.${system} or null;
+          aspect = lowkeylab-nix.packages.x86_64-linux.aspect;
+        in
+        {
+          inherit pkgs aspect;
+        };
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          inherit (mkPackagesForSystem system) aspect;
+        in
+        {
+          inherit aspect;
+          default = aspect;
+        }
+      );
+      devShells = forAllSystems (
+        system:
+        let
+          inherit (mkPackagesForSystem system) pkgs aspect;
           bazel =
             if pkgs.stdenv.isLinux then
               pkgs.buildFHSEnv {
@@ -71,15 +59,6 @@
               }
             else
               pkgs.writeShellScriptBin "bazel" ''exec bazelisk "$@"'';
-          aspect =
-            if aspectBinary == null then
-              null
-            else
-              mkFetchedBinary {
-                name = "aspect";
-                inherit (binaryReleases.aspect) version;
-                inherit (aspectBinary) url sha256;
-              };
           format = pkgs.writeShellScriptBin "format" ''exec bazel run //tools/format -- "$@"'';
           coverage = pkgs.writeShellScriptBin "coverage" ''exec bazel run //tools/coverage -- "$@"'';
         in
@@ -105,7 +84,7 @@
               pkgs.nodejs_24 # provides node/npm for agent-browser
               pkgs.cargo
               pkgs.lcov
-            ] ++ pkgs.lib.optionals (aspect != null) [
+            ] ++ [
               aspect
             ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
               pkgs.chromium # hermetic browser — use with: agent-browser --executable-path $(which chromium)


### PR DESCRIPTION
## Summary
- source the repo flake's `aspect` package from `LowkeyLab/nix` and keep the upstream Aspect CLI pinned to the previously verified `v2026.4.2` release
- narrow the flake assumption to `x86_64-linux` for now and remove the previous fallback package paths
- update CI and root docs so `aspect` is built from `.#aspect` and the platform assumption is explicit

## Verification
- `nix build .#aspect`
- `nix develop --command bash -lc \"bazel run gazelle && format && aspect build //...\"`