### PR TITLE
ci: switch workflows to Determinate nix installer

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -33,8 +33,6 @@ jobs:
             test --test_env=XDG_CACHE_HOME
       - uses: DeterminateSystems/nix-installer-action@92148bb48b9a0c5458c53dd0b368fbfbfbaa3210
         with:
-          determinate: true
-          trust-runner-user: true
           extra-conf: |
             experimental-features = nix-command flakes
       - name: Install tools via flake

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -33,6 +33,8 @@ jobs:
             test --test_env=XDG_CACHE_HOME
       - uses: DeterminateSystems/nix-installer-action@92148bb48b9a0c5458c53dd0b368fbfbfbaa3210
         with:
+          determinate: true
+          trust-runner-user: true
           extra-conf: |
             experimental-features = nix-command flakes
       - name: Install tools via flake

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -31,9 +31,9 @@ jobs:
             common --config=ci
             build --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}
             test --test_env=XDG_CACHE_HOME
-      - uses: cachix/install-nix-action@616559265b40713947b9c190a8ff4b507b5df49b # v31
+      - uses: DeterminateSystems/nix-installer-action@92148bb48b9a0c5458c53dd0b368fbfbfbaa3210
         with:
-          extra_nix_config: |
+          extra-conf: |
             experimental-features = nix-command flakes
       - name: Install tools via flake
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,8 +20,6 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@92148bb48b9a0c5458c53dd0b368fbfbfbaa3210
         with:
-          determinate: true
-          trust-runner-user: true
           extra-conf: |
             experimental-features = nix-command flakes
       - name: Configure Magic Nix Cache

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,6 +20,8 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@92148bb48b9a0c5458c53dd0b368fbfbfbaa3210
         with:
+          determinate: true
+          trust-runner-user: true
           extra-conf: |
             experimental-features = nix-command flakes
       - name: Configure Magic Nix Cache

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,9 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install Nix
-        uses: cachix/install-nix-action@616559265b40713947b9c190a8ff4b507b5df49b
+        uses: DeterminateSystems/nix-installer-action@92148bb48b9a0c5458c53dd0b368fbfbfbaa3210
         with:
-          extra_nix_config: |
+          extra-conf: |
             experimental-features = nix-command flakes
       - name: Configure Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39


### PR DESCRIPTION
## Summary
- replace `cachix/install-nix-action` with `DeterminateSystems/nix-installer-action` in the test and Copilot workflows
- keep flakes enabled by translating `extra_nix_config` to Determinate's `extra-conf`
- preserve the existing Magic Nix Cache and downstream `nix build` / `nix develop` steps unchanged