### PR TITLE
fix: repair Mindreadr Vitest CI

### DIFF
--- a/angular/projects/mindreadr/src/app/game-summary/game-summary.component.spec.ts
+++ b/angular/projects/mindreadr/src/app/game-summary/game-summary.component.spec.ts
@@ -1,12 +1,9 @@
 import { TestBed } from '@angular/core/testing';
-import { vi } from 'vitest';
 import { ActivatedRoute, Router } from '@angular/router';
+import { vi } from 'vitest';
 
-vi.mock('canvas-confetti', () => ({
-  default: vi.fn(),
-}));
+import type { GameDto } from '../services/game.types';
 import { GameSummaryComponent } from './game-summary.component';
-import { GameDto } from '../services/game.types';
 
 describe('GameSummaryComponent', () => {
   const TEST_ANIMATION_DELAY = 50; // Use faster delay for tests
@@ -15,11 +12,14 @@ describe('GameSummaryComponent', () => {
     vi.useRealTimers();
   });
 
-  function createComponentWithNavState(state: any, id: string | null = 'g1') {
+  function createComponentWithNavState(
+    state: Record<string, unknown>,
+    id: string | null = 'g1',
+  ) {
     const routerSpy = {
       currentNavigation: () => ({ extras: { state } }),
       navigate: vi.fn(),
-    } as any as Router;
+    } as unknown as Router;
     TestBed.configureTestingModule({
       imports: [GameSummaryComponent],
       providers: [

--- a/angular/projects/mindreadr/vitest-base.config.ts
+++ b/angular/projects/mindreadr/vitest-base.config.ts
@@ -1,12 +1,15 @@
-import { defineConfig } from 'vitest/config';
-import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-// Write coverage to a known location relative to the config file so the
-// globalSetup teardown can reliably find it.
-const reportsDirectory = join(__dirname, '.vitest-coverage');
+// Write coverage to a writable Bazel test temp directory when available so
+// Vitest does not try to clean up files under the read-only runfiles tree.
+const reportsDirectory = join(
+  process.env.TEST_TMPDIR ?? __dirname,
+  '.vitest-coverage',
+);
 
 export default defineConfig({
   test: {

--- a/angular/projects/mindreadr/vitest-global-setup.ts
+++ b/angular/projects/mindreadr/vitest-global-setup.ts
@@ -3,12 +3,16 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 export async function teardown() {
-  const coverageOutputFile = process.env['COVERAGE_OUTPUT_FILE'];
+  const coverageOutputFile = process.env.COVERAGE_OUTPUT_FILE;
   // No-op when not running under `bazel coverage`.
   if (!coverageOutputFile) return;
 
   const __dirname = dirname(fileURLToPath(import.meta.url));
-  const lcovSrc = join(__dirname, '.vitest-coverage', 'lcov.info');
+  const reportsDirectory = join(
+    process.env.TEST_TMPDIR ?? __dirname,
+    '.vitest-coverage',
+  );
+  const lcovSrc = join(reportsDirectory, 'lcov.info');
 
   if (!existsSync(lcovSrc)) {
     process.stderr.write(


### PR DESCRIPTION
## Summary
- Remove the top-level `canvas-confetti` Vitest mock that trips Angular's mock patch in the Mindreadr summary spec.
- Write Mindreadr Vitest coverage reports under Bazel's writable `TEST_TMPDIR` so normal test runs do not clean up read-only runfiles.
- Keep the spec helper type-safe while preserving the existing Router stub behavior.

## Verification
- `bazel run gazelle`
- `format`
- `aspect test //angular/projects/mindreadr:test`
- `aspect build //...`

Note: the verification above passed before moving the same diff into the requested worktree; the repeated worktree `aspect test //angular/projects/mindreadr:test` also passed, while the repeated full build was interrupted by the user.