### PR TITLE
build: source agent-browser from llm-agents flake

### DIFF
--- a/angular/projects/nicknamer2-web/CLAUDE.md
+++ b/angular/projects/nicknamer2-web/CLAUDE.md
@@ -33,7 +33,7 @@ graphql-codegen --config angular/projects/nicknamer2-web/codegen.ts
 
 ## E2E Testing with agent-browser
 
-After UI changes, run an E2E smoke test using `agent-browser`. Requires the full stack running:
+After UI changes, run an E2E smoke test using `agent-browser`. The CLI is provided by the Nix dev shell via `github:numtide/llm-agents.nix`; on Linux, that wrapper points at the shell-provided Chromium automatically. Requires the full stack running:
 
 ```bash
 # 1. Start infrastructure

--- a/flake.lock
+++ b/flake.lock
@@ -20,10 +20,13 @@
     "blueprint": {
       "inputs": {
         "nixpkgs": [
-          "lowkeylab-nix",
+          "llm-agents",
           "nixpkgs"
         ],
-        "systems": "systems"
+        "systems": [
+          "llm-agents",
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1776249299,
@@ -39,12 +42,114 @@
         "type": "github"
       }
     },
+    "blueprint_2": {
+      "inputs": {
+        "nixpkgs": [
+          "lowkeylab-nix",
+          "nixpkgs"
+        ],
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1776249299,
+        "narHash": "sha256-Dt9t1TGRmJFc0xVYhttNBD6QsAgHOHCArqGa0AyjrJY=",
+        "owner": "numtide",
+        "repo": "blueprint",
+        "rev": "56131e8628f173d24a27f6d27c0215eff57e40dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "blueprint",
+        "type": "github"
+      }
+    },
+    "bun2nix": {
+      "inputs": {
+        "flake-parts": [
+          "llm-agents",
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "llm-agents",
+          "nixpkgs"
+        ],
+        "systems": [
+          "llm-agents",
+          "systems"
+        ],
+        "treefmt-nix": [
+          "llm-agents",
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777369708,
+        "narHash": "sha256-1xW7cRZNsFNPQD+cE0fwnLVStnDth0HSoASEIFeT7uI=",
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "rev": "e659e1cc4b8e1b21d0aa85f1c481f9db61ecfa98",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "staging-2.1.0",
+        "repo": "bun2nix",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "llm-agents",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "llm-agents": {
+      "inputs": {
+        "blueprint": "blueprint",
+        "bun2nix": "bun2nix",
+        "flake-parts": "flake-parts",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1777585133,
+        "narHash": "sha256-g8i3Y8HGNNOS2p8rtprkkp1sNYE9CgqQvXhj5qjj6JQ=",
+        "owner": "numtide",
+        "repo": "llm-agents.nix",
+        "rev": "bf96ed626970bd1659abc63a5d4a90146d100ad3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "llm-agents.nix",
+        "type": "github"
+      }
+    },
     "lowkeylab-nix": {
       "inputs": {
         "aspect-cli-src": [
           "aspect-cli-src"
         ],
-        "blueprint": "blueprint",
+        "blueprint": "blueprint_2",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -82,6 +187,7 @@
     "root": {
       "inputs": {
         "aspect-cli-src": "aspect-cli-src",
+        "llm-agents": "llm-agents",
         "lowkeylab-nix": "lowkeylab-nix",
         "nixpkgs": "nixpkgs"
       }
@@ -98,6 +204,42 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "llm-agents",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -12,10 +12,19 @@
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.aspect-cli-src.follows = "aspect-cli-src";
     };
+    llm-agents = {
+      url = "github:numtide/llm-agents.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
-    { nixpkgs, lowkeylab-nix, ... }:
+    {
+      nixpkgs,
+      lowkeylab-nix,
+      llm-agents,
+      ...
+    }:
     let
       supportedSystems = [
         "x86_64-linux"
@@ -26,9 +35,10 @@
         let
           pkgs = nixpkgs.legacyPackages.${system};
           aspect = lowkeylab-nix.packages.${system}.aspect;
+          agent-browser = llm-agents.packages.${system}.agent-browser;
         in
         {
-          inherit pkgs aspect;
+          inherit pkgs aspect agent-browser;
         };
     in
     {
@@ -45,7 +55,7 @@
       devShells = forAllSystems (
         system:
         let
-          inherit (mkPackagesForSystem system) pkgs aspect;
+          inherit (mkPackagesForSystem system) pkgs aspect agent-browser;
           bazel =
             if pkgs.stdenv.isLinux then
               pkgs.buildFHSEnv {
@@ -81,13 +91,14 @@
               pkgs.jdk21_headless
               pkgs.gcc
               pkgs.pre-commit
-              pkgs.nodejs_24 # provides node/npm for agent-browser
+              agent-browser
+              pkgs.nodejs_24
               pkgs.cargo
               pkgs.lcov
             ] ++ [
               aspect
             ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
-              pkgs.chromium # hermetic browser — use with: agent-browser --executable-path $(which chromium)
+              pkgs.chromium
             ];
 
             # Linux: set NIX_LD so bazelisk can run downloaded Bazel binaries
@@ -100,7 +111,7 @@
                 pkgs.stdenv.cc.cc.lib
                 pkgs.zlib
 
-                # Chrome/Chromium runtime deps for agent-browser
+                # Chrome/Chromium runtime deps for browser tooling
                 pkgs.libxcb
                 pkgs.libx11
                 pkgs.libxext
@@ -129,8 +140,8 @@
                 pkgs.nss
                 pkgs.nspr
               ];
-              # Point agent-browser at Nix-provided Chromium (Linux-only;
-              # on Darwin, agent-browser auto-detects Chrome from /Applications).
+              # Keep Chromium discoverable for browser tooling.
+              # agent-browser is wrapped by llm-agents.nix with its own browser path.
               # CHROME_BIN is the same path under a different name — karma-chrome-launcher
               # reads CHROME_BIN to locate the browser for `bazel coverage` on Karma tests.
               CHROME_PATH = pkgs.lib.getExe pkgs.chromium;

--- a/tools/tools.lock.json
+++ b/tools/tools.lock.json
@@ -1,30 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/theoremlp/rules_multitool/main/lockfile.schema.json",
-  "agent-browser": {
-    "binaries": [
-      {
-        "kind": "file",
-        "url": "https://github.com/vercel-labs/agent-browser/releases/download/v0.26.0/agent-browser-linux-arm64",
-        "sha256": "b3901b17298f6ce6511fcae5c576068a3e8a510ecb365c8ccd876b9b82db4447",
-        "os": "linux",
-        "cpu": "arm64"
-      },
-      {
-        "kind": "file",
-        "url": "https://github.com/vercel-labs/agent-browser/releases/download/v0.26.0/agent-browser-linux-x64",
-        "sha256": "8784dc259abf72ee04e751b45677d956387af50c99aec5dcd7a41a9bc498e3c3",
-        "os": "linux",
-        "cpu": "x86_64"
-      },
-      {
-        "kind": "file",
-        "url": "https://github.com/vercel-labs/agent-browser/releases/download/v0.26.0/agent-browser-darwin-arm64",
-        "sha256": "18f7af7c57ab522bd80f64112b8d7ff43e63a98d98064ba13a96363aa9ae2650",
-        "os": "macos",
-        "cpu": "arm64"
-      }
-    ]
-  },
   "aspect": {
     "binaries": [
       {


### PR DESCRIPTION
## Summary
- Source `agent-browser` from `github:numtide/llm-agents.nix` in the Nix dev shell.
- Remove the old multitool-managed `agent-browser` binary lock entry.
- Document the new dev shell source for Nicknamer web E2E smoke tests.

## Verification
- `nix flake check --no-build`
- `python3 -m json.tool tools/tools.lock.json`
- `nix develop -c agent-browser --help`
- `bazel run gazelle`
- `format`
- `aspect build //...`