### PR TITLE
build: track aspect cli from head

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -1,0 +1,13 @@
+def config(ctx):
+    ctx.tasks["lint"].args.aspects = [
+        "//tools/lint:linters.bzl%buf",
+        "//tools/lint:linters.bzl%eslint",
+        "//tools/lint:linters.bzl%stylelint",
+        "//tools/lint:linters.bzl%ruff",
+        "//tools/lint:linters.bzl%shellcheck",
+        "//tools/lint:linters.bzl%pmd",
+        "//tools/lint:linters.bzl%checkstyle",
+        "//tools/lint:linters.bzl%ktlint",
+        "//tools/lint:linters.bzl%clippy",
+        "//tools/lint:linters.bzl%keep_sorted",
+    ]

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,6 +32,7 @@ jobs:
           bazelisk-cache: true
           bazelrc: |
             common --config=ci
+            common --remote_download_toplevel
             common:lint --config=ci-lint
             common --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}
             test --test_env=XDG_CACHE_HOME

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,7 +32,7 @@ jobs:
           bazelisk-cache: true
           bazelrc: |
             common --config=ci
-            common --remote_download_toplevel
+            common --remote_download_outputs=all
             common:lint --config=ci-lint
             common --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}
             test --test_env=XDG_CACHE_HOME

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -33,6 +33,7 @@ jobs:
           bazelrc: |
             common --config=ci
             common --remote_download_outputs=all
+            common --nobuild_event_binary_file_path_conversion
             common:lint --config=ci-lint
             common --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}
             test --test_env=XDG_CACHE_HOME

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -50,18 +50,7 @@ jobs:
         env:
           ASPECT_API_TOKEN: ${{ secrets.ASPECT_API_TOKEN }}
         run: |
-          aspect lint \
-            --aspect //tools/lint:linters.bzl%buf \
-            --aspect //tools/lint:linters.bzl%eslint \
-            --aspect //tools/lint:linters.bzl%stylelint \
-            --aspect //tools/lint:linters.bzl%ruff \
-            --aspect //tools/lint:linters.bzl%shellcheck \
-            --aspect //tools/lint:linters.bzl%pmd \
-            --aspect //tools/lint:linters.bzl%checkstyle \
-            --aspect //tools/lint:linters.bzl%ktlint \
-            --aspect //tools/lint:linters.bzl%clippy \
-            --aspect //tools/lint:linters.bzl%keep_sorted \
-            //...
+          aspect lint //...
       - name: Run Bazel tests (remote)
         run: |
           bazel test //... --config=ci-remote

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -45,7 +45,18 @@ jobs:
           install -Dm755 ./result/bin/aspect /usr/local/bin/aspect
       - name: Run Bazel Lints
         run: |
-          aspect lint //...
+          aspect lint \
+            --aspect //tools/lint:linters.bzl%buf \
+            --aspect //tools/lint:linters.bzl%eslint \
+            --aspect //tools/lint:linters.bzl%stylelint \
+            --aspect //tools/lint:linters.bzl%ruff \
+            --aspect //tools/lint:linters.bzl%shellcheck \
+            --aspect //tools/lint:linters.bzl%pmd \
+            --aspect //tools/lint:linters.bzl%checkstyle \
+            --aspect //tools/lint:linters.bzl%ktlint \
+            --aspect //tools/lint:linters.bzl%clippy \
+            --aspect //tools/lint:linters.bzl%keep_sorted \
+            //...
       - name: Run Bazel tests (remote)
         run: |
           bazel test //... --config=ci-remote

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@92148bb48b9a0c5458c53dd0b368fbfbfbaa3210
         with:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -46,6 +46,8 @@ jobs:
           nix build .#aspect
           install -Dm755 ./result/bin/aspect /usr/local/bin/aspect
       - name: Run Bazel Lints
+        env:
+          ASPECT_API_TOKEN: ${{ secrets.ASPECT_API_TOKEN }}
         run: |
           aspect lint \
             --aspect //tools/lint:linters.bzl%buf \

--- a/MODULE.aspect
+++ b/MODULE.aspect
@@ -5,6 +5,5 @@ axl_archive_dep(
     integrity = "sha256-qWqBKcNP3dILV0Jwoa1ovT1NkwcRGej+KC2Fld83UrM=",
     strip_prefix = "rules_lint-2.1.0",
     dev = True,
-    auto_use_tasks = True,
+    auto_use_tasks = False,
 )
-

--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,15 @@
     "aspect-cli-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1769121247,
-        "narHash": "sha256-N3y+MS19aPI9BQwvrrkrt5u9x9/WE28syStfOLe4aPM=",
+        "lastModified": 1777583996,
+        "narHash": "sha256-BQDTXKB/wtr1OsNe7tXW/nw/k3AR1YqJoTGfhJ40VJ4=",
         "owner": "aspect-build",
         "repo": "aspect-cli",
-        "rev": "2a995acc48c4035b9195fbc8030473e2073b5265",
+        "rev": "d10fc5b4d55151ac21a954af736b4363604cb84e",
         "type": "github"
       },
       "original": {
         "owner": "aspect-build",
-        "ref": "v2026.4.2",
         "repo": "aspect-cli",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -145,9 +145,7 @@
     },
     "lowkeylab-nix": {
       "inputs": {
-        "aspect-cli-src": [
-          "aspect-cli-src"
-        ],
+        "aspect-cli-src": "aspect-cli-src",
         "blueprint": "blueprint_2",
         "nixpkgs": [
           "nixpkgs"
@@ -185,7 +183,6 @@
     },
     "root": {
       "inputs": {
-        "aspect-cli-src": "aspect-cli-src",
         "llm-agents": "llm-agents",
         "lowkeylab-nix": "lowkeylab-nix",
         "nixpkgs": "nixpkgs"

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     aspect-cli-src = {
-      url = "github:aspect-build/aspect-cli/v2026.4.2";
+      url = "github:aspect-build/aspect-cli";
       flake = false;
     };
     lowkeylab-nix = {

--- a/flake.nix
+++ b/flake.nix
@@ -3,14 +3,9 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    aspect-cli-src = {
-      url = "github:aspect-build/aspect-cli";
-      flake = false;
-    };
     lowkeylab-nix = {
       url = "github:LowkeyLab/nix";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.aspect-cli-src.follows = "aspect-cli-src";
     };
     llm-agents = {
       url = "github:numtide/llm-agents.nix";


### PR DESCRIPTION
## Summary
- Update the Aspect CLI flake input to track the repository head instead of the `v2026.4.2` tag.
- Refresh `flake.lock` to `aspect-build/aspect-cli` revision `d10fc5b4d55151ac21a954af736b4363604cb84e`.

## Verification
- `nix flake show --all-systems`
- `nix build .#aspect`
- `/home/tacascer/Projects/bazel-repo/.worktrees/build-aspect-cli-head/result/bin/aspect --version` → `aspect 0.0.0-dev`