### PR TITLE
feat(pinyin): pdf export

### DIFF
--- a/angular/projects/pinyin-composer/src/app/editor/browser-print.service.spec.ts
+++ b/angular/projects/pinyin-composer/src/app/editor/browser-print.service.spec.ts
@@ -1,0 +1,29 @@
+import { TestBed } from '@angular/core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { BrowserPrintService } from './browser-print.service';
+
+describe('BrowserPrintService', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls window.print once', () => {
+    const printSpy = vi.spyOn(window, 'print').mockImplementation(() => {});
+    const service = TestBed.inject(BrowserPrintService);
+
+    service.print();
+
+    expect(printSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates print errors', () => {
+    const printError = new Error('print failed');
+    vi.spyOn(window, 'print').mockImplementation(() => {
+      throw printError;
+    });
+    const service = TestBed.inject(BrowserPrintService);
+
+    expect(() => service.print()).toThrow(printError);
+  });
+});

--- a/angular/projects/pinyin-composer/src/app/editor/browser-print.service.ts
+++ b/angular/projects/pinyin-composer/src/app/editor/browser-print.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class BrowserPrintService {
+  print(): void {
+    window.print();
+  }
+}

--- a/angular/projects/pinyin-composer/src/app/editor/pdf-export-document.component.spec.ts
+++ b/angular/projects/pinyin-composer/src/app/editor/pdf-export-document.component.spec.ts
@@ -1,0 +1,175 @@
+import { type ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PdfExportDocumentComponent } from './pdf-export-document.component';
+import type {
+  AnnotatedSpan,
+  DocumentSpan,
+  PlainTextSpan,
+} from './phrase-token';
+
+describe('PdfExportDocumentComponent', () => {
+  let fixture: ComponentFixture<PdfExportDocumentComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PdfExportDocumentComponent],
+    }).compileComponents();
+    fixture = TestBed.createComponent(PdfExportDocumentComponent);
+  });
+
+  it('renders plain text newlines as line breaks without dropping text', () => {
+    setSpans(fixture, [plainSpan('plain-1', 'first\n\nsecond')]);
+
+    const root = queryByTestId(fixture, 'pdf-export-document');
+    const plainFragments = queryAllByTestId(fixture, 'pdf-export-plain');
+    const lineBreaks = queryAllByTestId(fixture, 'pdf-export-line-break');
+    const sequence = exportNodes(fixture);
+
+    expect(root.classList.contains('pdf-export-document')).toBe(true);
+    expect(plainFragments.map((element) => element.textContent)).toEqual([
+      'first',
+      'second',
+    ]);
+    expect(lineBreaks.length).toBe(2);
+    expect(sequence).toEqual([
+      'pdf-export-plain',
+      'pdf-export-line-break',
+      'pdf-export-line-break',
+      'pdf-export-plain',
+    ]);
+  });
+
+  it('renders annotated text newlines with ruby fragments and shared pinyin', () => {
+    setSpans(fixture, [
+      annotatedSpan('annotated-1', 'nihao', '你\n好', 'Nǐ Hǎo'),
+    ]);
+
+    const rubyElements = queryAllByTestId(fixture, 'pdf-export-ruby');
+    const lineBreaks = queryAllByTestId(fixture, 'pdf-export-line-break');
+    const sequence = exportNodes(fixture);
+
+    expect(rubyElements.length).toBe(2);
+    expect(rubyElements[0].querySelector('rb')?.textContent).toBe('你');
+    expect(rubyElements[0].querySelector('rt')?.textContent).toBe('Nǐ Hǎo');
+    expect(rubyElements[1].querySelector('rb')?.textContent).toBe('好');
+    expect(rubyElements[1].querySelector('rt')?.textContent).toBe('Nǐ Hǎo');
+    expect(lineBreaks.length).toBe(1);
+    expect(sequence).toEqual([
+      'pdf-export-ruby',
+      'pdf-export-line-break',
+      'pdf-export-ruby',
+    ]);
+  });
+
+  it('preserves consecutive, leading, and trailing newlines exactly', () => {
+    setSpans(fixture, [
+      plainSpan('plain-1', '\nfirst\n\nsecond\n'),
+      annotatedSpan('annotated-1', 'hao', '\n好\n', 'Hǎo'),
+    ]);
+
+    const lineBreaks = queryAllByTestId(fixture, 'pdf-export-line-break');
+    const plainFragments = queryAllByTestId(fixture, 'pdf-export-plain');
+    const rubyElements = queryAllByTestId(fixture, 'pdf-export-ruby');
+
+    expect(lineBreaks.length).toBe(6);
+    expect(plainFragments.map((element) => element.textContent)).toEqual([
+      'first',
+      'second',
+    ]);
+    expect(rubyElements.length).toBe(1);
+    expect(rubyElements[0].querySelector('rb')?.textContent).toBe('好');
+  });
+
+  it('renders mixed spans in original order and handles empty spans', () => {
+    setSpans(fixture, [
+      plainSpan('plain-1', 'a\n'),
+      annotatedSpan('annotated-1', 'nihao', '你\n好', 'Nǐ Hǎo'),
+      plainSpan('plain-2', ''),
+    ]);
+
+    expect(exportNodes(fixture)).toEqual([
+      'pdf-export-plain',
+      'pdf-export-line-break',
+      'pdf-export-ruby',
+      'pdf-export-line-break',
+      'pdf-export-ruby',
+    ]);
+    expect(queryAllByTestId(fixture, 'pdf-export-plain').length).toBe(1);
+  });
+
+  it('renders no fragments for empty spans', () => {
+    setSpans(fixture, [plainSpan('plain-1', '')]);
+
+    expect(queryAllByTestId(fixture, 'pdf-export-plain').length).toBe(0);
+    expect(queryAllByTestId(fixture, 'pdf-export-ruby').length).toBe(0);
+    expect(queryAllByTestId(fixture, 'pdf-export-line-break').length).toBe(0);
+  });
+});
+
+function setSpans(
+  fixture: ComponentFixture<PdfExportDocumentComponent>,
+  spans: readonly DocumentSpan[],
+): void {
+  fixture.componentRef.setInput('spans', spans);
+  fixture.detectChanges();
+}
+
+function annotatedSpan(
+  id: string,
+  sourcePinyin: string,
+  text: string,
+  displayPinyin: string,
+): AnnotatedSpan {
+  return {
+    id,
+    kind: 'annotated',
+    sourcePinyin,
+    text,
+    displayPinyin,
+    annotationScope: 'atomicPhrase',
+  };
+}
+
+function plainSpan(id: string, text: string): PlainTextSpan {
+  return {
+    id,
+    kind: 'plain',
+    text,
+  };
+}
+
+function exportNodes(
+  fixture: ComponentFixture<PdfExportDocumentComponent>,
+): string[] {
+  const root = fixture.nativeElement as HTMLElement;
+  const elements = Array.from(
+    root.querySelectorAll<HTMLElement>(
+      '[data-testid="pdf-export-plain"], [data-testid="pdf-export-ruby"], [data-testid="pdf-export-line-break"]',
+    ),
+  );
+
+  return elements.map((element) => element.getAttribute('data-testid') ?? '');
+}
+
+function queryByTestId(
+  fixture: ComponentFixture<PdfExportDocumentComponent>,
+  testId: string,
+): HTMLElement {
+  const element = fixture.nativeElement.querySelector(
+    `[data-testid="${testId}"]`,
+  ) as HTMLElement | null;
+  if (!element) {
+    throw new Error(`Expected element for ${testId}`);
+  }
+
+  return element;
+}
+
+function queryAllByTestId(
+  fixture: ComponentFixture<PdfExportDocumentComponent>,
+  testId: string,
+): HTMLElement[] {
+  return Array.from(
+    fixture.nativeElement.querySelectorAll(`[data-testid="${testId}"]`),
+  ) as HTMLElement[];
+}

--- a/angular/projects/pinyin-composer/src/app/editor/pdf-export-document.component.ts
+++ b/angular/projects/pinyin-composer/src/app/editor/pdf-export-document.component.ts
@@ -39,6 +39,31 @@ import type { DocumentSpan } from './phrase-token';
       .pdf-export-document {
         white-space: pre-wrap;
       }
+
+      @media print {
+        .pdf-export-document {
+          color: var(--composer-page-ink);
+          line-height: var(--composer-page-print-line-height);
+          white-space: pre-wrap;
+        }
+
+        .pdf-export-ruby,
+        .pdf-export-plain {
+          color: var(--composer-page-ink);
+          padding: 0 var(--composer-page-space-sm);
+        }
+
+        br {
+          display: block;
+        }
+
+        rt {
+          color: var(--composer-page-ink);
+          font-size: var(--composer-page-print-ruby-scale);
+          line-height: 1;
+          visibility: visible;
+        }
+      }
     `,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/angular/projects/pinyin-composer/src/app/editor/pdf-export-document.component.ts
+++ b/angular/projects/pinyin-composer/src/app/editor/pdf-export-document.component.ts
@@ -1,0 +1,90 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+
+import type { DocumentSpan } from './phrase-token';
+
+@Component({
+  selector: 'app-pdf-export-document',
+  template: `
+    <div class="pdf-export-document" data-testid="pdf-export-document">
+      @for (span of spans(); track span.id) {
+        @if (span.kind === 'annotated') {
+          @for (fragment of splitText(span.text); track fragment.index) {
+            @if (fragment.kind === 'text') {
+              <ruby data-testid="pdf-export-ruby">
+                <rb>{{ fragment.text }}</rb>
+                <rt>{{ span.displayPinyin }}</rt>
+              </ruby>
+            } @else {
+              <br data-testid="pdf-export-line-break" />
+            }
+          }
+        } @else {
+          @for (fragment of splitText(span.text); track fragment.index) {
+            @if (fragment.kind === 'text') {
+              <span data-testid="pdf-export-plain">{{ fragment.text }}</span>
+            } @else {
+              <br data-testid="pdf-export-line-break" />
+            }
+          }
+        }
+      }
+    </div>
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+
+      .pdf-export-document {
+        white-space: pre-wrap;
+      }
+    `,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PdfExportDocumentComponent {
+  readonly spans = input.required<readonly DocumentSpan[]>();
+
+  protected splitText(text: string): readonly PdfExportFragment[] {
+    const fragments: PdfExportFragment[] = [];
+    let startIndex = 0;
+
+    for (let index = 0; index < text.length; index += 1) {
+      if (text[index] === '\n') {
+        if (index > startIndex) {
+          fragments.push({
+            kind: 'text',
+            index: fragments.length,
+            text: text.slice(startIndex, index),
+          });
+        }
+        fragments.push({ kind: 'line-break', index: fragments.length });
+        startIndex = index + 1;
+      }
+    }
+
+    if (startIndex < text.length) {
+      fragments.push({
+        kind: 'text',
+        index: fragments.length,
+        text: text.slice(startIndex),
+      });
+    }
+
+    return fragments;
+  }
+}
+
+type PdfExportFragment = PdfExportTextFragment | PdfExportLineBreakFragment;
+
+interface PdfExportTextFragment {
+  readonly kind: 'text';
+  readonly index: number;
+  readonly text: string;
+}
+
+interface PdfExportLineBreakFragment {
+  readonly kind: 'line-break';
+  readonly index: number;
+}

--- a/angular/projects/pinyin-composer/src/app/editor/pinyin-composer-page.component.spec.ts
+++ b/angular/projects/pinyin-composer/src/app/editor/pinyin-composer-page.component.spec.ts
@@ -3,6 +3,7 @@ import { By } from '@angular/platform-browser';
 
 import { LocalDocumentStoreService } from '../documents/local-document-store.service';
 import { ConversionWorkerClient } from '../wasm/conversion-worker.client';
+import { BrowserPrintService } from './browser-print.service';
 import {
   DocumentEditorComponent,
   type DocumentTextReplacement,
@@ -20,16 +21,19 @@ import { PinyinComposerPageComponent } from './pinyin-composer-page.component';
 describe('PinyinComposerPageComponent', () => {
   let conversion: FakeConversionWorkerClient;
   let documents: FakeLocalDocumentStoreService;
+  let browserPrint: FakeBrowserPrintService;
   let fixture: ComponentFixture<PinyinComposerPageComponent>;
   let editor: EditorStateService;
 
   beforeEach(async () => {
     conversion = new FakeConversionWorkerClient();
     documents = new FakeLocalDocumentStoreService();
+    browserPrint = new FakeBrowserPrintService();
 
     await TestBed.configureTestingModule({
       imports: [PinyinComposerPageComponent],
       providers: [
+        { provide: BrowserPrintService, useValue: browserPrint },
         { provide: ConversionWorkerClient, useValue: conversion },
         { provide: LocalDocumentStoreService, useValue: documents },
       ],
@@ -40,14 +44,102 @@ describe('PinyinComposerPageComponent', () => {
     fixture.detectChanges();
   });
 
-  it('renders the document editor controls without legacy input or export UI', () => {
+  it('renders the document editor controls with the export action', () => {
     const legacyExportTestId = ['html', 'export'].join('-');
+    const exportSurface = queryByTestIdRequired(fixture, 'pdf-export-surface');
 
     expect(queryByTestId(fixture, 'document-editor')).not.toBeNull();
     expect(queryByTestId(fixture, 'document-title')).not.toBeNull();
     expect(queryByTestId(fixture, 'save-document')).not.toBeNull();
+    expect(queryByTestId(fixture, 'export-pdf')).not.toBeNull();
+    expect(exportSurface.classList.contains('pdf-export-surface')).toBe(true);
+    expect(exportSurface.hasAttribute('hidden')).toBe(false);
+    expect(exportSurface.hasAttribute('inert')).toBe(true);
     expect(queryByTestId(fixture, 'pinyin-input')).toBeNull();
     expect(queryByTestId(fixture, legacyExportTestId)).toBeNull();
+  });
+
+  it('disables export and skips printing when the document is empty', () => {
+    const exportButton = queryByTestIdRequired(
+      fixture,
+      'export-pdf',
+    ) as HTMLButtonElement;
+
+    expect(exportButton.disabled).toBe(true);
+
+    exportButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    fixture.componentInstance.exportPdf();
+
+    expect(browserPrint.printCallCount).toBe(0);
+  });
+
+  it('renders newline-aware PDF content and prints once from the export action', () => {
+    fixture.componentInstance.documentTitle.set('Document');
+    editor.loadDocument(
+      documentWithSpans([
+        annotatedSpan('span-bei', 'bei', '北', 'Běi'),
+        plainSpan('line-break', '\n'),
+        annotatedSpan('span-jing', 'jing', '京', 'jīng'),
+      ]),
+    );
+    fixture.detectChanges();
+
+    const exportButton = queryByTestIdRequired(
+      fixture,
+      'export-pdf',
+    ) as HTMLButtonElement;
+    const exportSurface = queryByTestIdRequired(fixture, 'pdf-export-surface');
+    const exportSurfaceText = exportSurface.textContent ?? '';
+    const exportNodes = exportSurfaceNodes(exportSurface);
+
+    expect(exportButton.disabled).toBe(false);
+    expect(exportSurface.classList.contains('pdf-export-surface')).toBe(true);
+    expect(exportSurfaceText).not.toContain('Document');
+    expect(exportSurfaceText).not.toContain('Untitled pinyin document');
+    expect(exportSurfaceText).not.toContain('2026-05-06T00:00:00.000Z');
+    expect(exportNodes.map((node) => node.testId)).toEqual([
+      'pdf-export-ruby',
+      'pdf-export-line-break',
+      'pdf-export-ruby',
+    ]);
+    expect(exportNodes[0].textContent).toContain('北');
+    expect(exportNodes[0].textContent).toContain('Běi');
+    expect(exportNodes[1].textContent).toBe('');
+    expect(exportNodes[2].textContent).toContain('京');
+    expect(exportNodes[2].textContent).toContain('jīng');
+
+    clickByTestId(fixture, 'export-pdf');
+
+    expect(browserPrint.printCallCount).toBe(1);
+  });
+
+  it('renders consecutive newlines as separate PDF export line breaks', () => {
+    editor.loadDocument(
+      documentWithSpans([
+        annotatedSpan('span-bei', 'bei', '北', 'Běi'),
+        plainSpan('blank-line', '\n\n'),
+        annotatedSpan('span-jing', 'jing', '京', 'jīng'),
+      ]),
+    );
+    fixture.detectChanges();
+
+    const exportSurface = queryByTestIdRequired(fixture, 'pdf-export-surface');
+    const exportNodes = exportSurfaceNodes(exportSurface);
+
+    expect(exportNodes.map((node) => node.testId)).toEqual([
+      'pdf-export-ruby',
+      'pdf-export-line-break',
+      'pdf-export-line-break',
+      'pdf-export-ruby',
+    ]);
+    expect(exportNodes[0].textContent).toContain('北');
+    expect(exportNodes[1].textContent).toBe('');
+    expect(exportNodes[2].textContent).toBe('');
+    expect(exportNodes[3].textContent).toContain('京');
+    expect(
+      exportSurface.querySelectorAll('[data-testid="pdf-export-line-break"]')
+        .length,
+    ).toBe(2);
   });
 
   it('commits the selected candidate into the pending typed range', async () => {
@@ -520,6 +612,14 @@ class FakeLocalDocumentStoreService implements Pick<
   }
 }
 
+class FakeBrowserPrintService implements Pick<BrowserPrintService, 'print'> {
+  printCallCount = 0;
+
+  print(): void {
+    this.printCallCount += 1;
+  }
+}
+
 function documentWithSpans(spans: readonly DocumentSpan[]): ComposerDocument {
   return {
     schemaVersion: 2,
@@ -724,6 +824,23 @@ function clickByTestId(
     throw new Error(`Expected clickable element for ${testId}`);
   }
   element.click();
+}
+
+interface ExportSurfaceNode {
+  readonly testId: string;
+  readonly textContent: string;
+}
+
+function exportSurfaceNodes(exportSurface: HTMLElement): ExportSurfaceNode[] {
+  return Array.from(
+    exportSurface.querySelectorAll<HTMLElement>(
+      '[data-testid="pdf-export-plain"], [data-testid="pdf-export-ruby"], [data-testid="pdf-export-line-break"]',
+    ),
+    (element) => ({
+      testId: element.getAttribute('data-testid') ?? '',
+      textContent: element.textContent ?? '',
+    }),
+  );
 }
 
 function candidateMenuText(

--- a/angular/projects/pinyin-composer/src/app/editor/pinyin-composer-page.component.spec.ts
+++ b/angular/projects/pinyin-composer/src/app/editor/pinyin-composer-page.component.spec.ts
@@ -96,7 +96,6 @@ describe('PinyinComposerPageComponent', () => {
     expect(exportSurface.classList.contains('pdf-export-surface')).toBe(true);
     expect(exportSurfaceText).not.toContain('Document');
     expect(exportSurfaceText).not.toContain('Untitled pinyin document');
-    expect(exportSurfaceText).not.toContain('2026-05-06T00:00:00.000Z');
     expect(exportNodes.map((node) => node.testId)).toEqual([
       'pdf-export-ruby',
       'pdf-export-line-break',

--- a/angular/projects/pinyin-composer/src/app/editor/pinyin-composer-page.component.ts
+++ b/angular/projects/pinyin-composer/src/app/editor/pinyin-composer-page.component.ts
@@ -8,17 +8,24 @@ import { FormsModule } from '@angular/forms';
 
 import { LocalDocumentStoreService } from '../documents/local-document-store.service';
 import { ConversionWorkerClient } from '../wasm/conversion-worker.client';
+import { BrowserPrintService } from './browser-print.service';
 import {
   DocumentEditorComponent,
   type DocumentTextReplacement,
 } from './document-editor.component';
 import { EditorStateService } from './editor-state.service';
 import { InlineCandidateMenuComponent } from './inline-candidate-menu.component';
+import { PdfExportDocumentComponent } from './pdf-export-document.component';
 import type { Candidate, DocumentRange } from './phrase-token';
 
 @Component({
   selector: 'app-pinyin-composer-page',
-  imports: [FormsModule, DocumentEditorComponent, InlineCandidateMenuComponent],
+  imports: [
+    FormsModule,
+    DocumentEditorComponent,
+    InlineCandidateMenuComponent,
+    PdfExportDocumentComponent,
+  ],
   template: `
     <main class="composer-page">
       <header>
@@ -57,13 +64,32 @@ import type { Candidate, DocumentRange } from './phrase-token';
         (candidateSelected)="commitCandidate($event)"
       />
 
-      <button
-        type="button"
-        data-testid="save-document"
-        (click)="saveCurrentDocument()"
+      <div class="document-actions">
+        <button
+          type="button"
+          data-testid="save-document"
+          (click)="saveCurrentDocument()"
+        >
+          Save Draft
+        </button>
+        <button
+          type="button"
+          data-testid="export-pdf"
+          [disabled]="!editor.hasContent()"
+          (click)="exportPdf()"
+        >
+          Export PDF
+        </button>
+      </div>
+
+      <section
+        class="pdf-export-surface"
+        data-testid="pdf-export-surface"
+        inert
+        aria-hidden="true"
       >
-        Save Draft
-      </button>
+        <app-pdf-export-document [spans]="editor.spans()" />
+      </section>
     </main>
   `,
   styles: [
@@ -82,6 +108,8 @@ import type { Candidate, DocumentRange } from './phrase-token';
         --composer-page-radius-md: 0.75rem;
         --composer-page-radius-pill: 999px;
         --composer-page-measure: 56rem;
+        --composer-page-print-line-height: 2.4;
+        --composer-page-print-ruby-scale: 0.45em;
         max-width: var(--composer-page-measure);
         margin: 0 auto;
         padding: var(--composer-page-space-xl);
@@ -107,6 +135,12 @@ import type { Candidate, DocumentRange } from './phrase-token';
         margin: var(--composer-page-space-sm) 0 var(--composer-page-space-lg);
       }
 
+      .document-actions {
+        display: flex;
+        gap: var(--composer-page-space-sm);
+        align-items: center;
+      }
+
       button {
         border: 1px solid var(--composer-page-ink);
         border-radius: var(--composer-page-radius-pill);
@@ -120,12 +154,96 @@ import type { Candidate, DocumentRange } from './phrase-token';
       .error {
         color: var(--composer-page-error);
       }
+
+      .pdf-export-surface {
+        position: absolute;
+        overflow: hidden;
+        clip: rect(0 0 0 0);
+        clip-path: inset(50%);
+        width: 1px;
+        height: 1px;
+        margin: -1px;
+        padding: 0;
+        border: 0;
+        white-space: nowrap;
+        pointer-events: none;
+      }
+
+      @media print {
+        :host {
+          background: var(--composer-page-surface);
+          color: var(--composer-page-ink);
+        }
+
+        .composer-page {
+          max-width: none;
+          margin: 0;
+          padding: 0;
+          background: var(--composer-page-surface);
+          color: var(--composer-page-ink);
+        }
+
+        header,
+        label,
+        input,
+        .document-editor-host,
+        .error,
+        app-inline-candidate-menu,
+        .document-actions {
+          display: none;
+        }
+
+        .pdf-export-surface {
+          position: static;
+          overflow: visible;
+          clip: auto;
+          clip-path: none;
+          width: auto;
+          height: auto;
+          margin: 0;
+          padding: 0;
+          border: 0;
+          white-space: normal;
+          pointer-events: auto;
+          background: var(--composer-page-surface);
+          color: var(--composer-page-ink);
+          line-height: var(--composer-page-print-line-height);
+        }
+
+        .pdf-export-surface app-pdf-export-document {
+          display: block;
+        }
+
+        :host ::ng-deep .pdf-export-surface .pdf-export-document {
+          color: var(--composer-page-ink);
+          line-height: var(--composer-page-print-line-height);
+          white-space: pre-wrap;
+        }
+
+        :host ::ng-deep .pdf-export-surface .pdf-export-ruby,
+        :host ::ng-deep .pdf-export-surface .pdf-export-plain {
+          color: var(--composer-page-ink);
+          padding: 0 var(--composer-page-space-sm);
+        }
+
+        :host ::ng-deep .pdf-export-surface br {
+          display: block;
+        }
+
+        :host ::ng-deep .pdf-export-surface rt {
+          color: var(--composer-page-ink);
+          font-size: var(--composer-page-print-ruby-scale);
+          line-height: 1;
+          visibility: visible;
+        }
+      }
     `,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PinyinComposerPageComponent {
   readonly editor = inject(EditorStateService);
+  private readonly browserPrint = inject(BrowserPrintService);
   private readonly conversion = inject(ConversionWorkerClient);
   private readonly documents = inject(LocalDocumentStoreService);
 
@@ -222,6 +340,14 @@ export class PinyinComposerPageComponent {
       spans: this.editor.spans(),
       updatedAtIso: new Date().toISOString(),
     });
+  }
+
+  exportPdf(): void {
+    if (!this.editor.hasContent()) {
+      return;
+    }
+
+    this.browserPrint.print();
   }
 
   private pendingRangeAfterReplacement(

--- a/angular/projects/pinyin-composer/src/app/editor/pinyin-composer-page.component.ts
+++ b/angular/projects/pinyin-composer/src/app/editor/pinyin-composer-page.component.ts
@@ -213,29 +213,6 @@ import type { Candidate, DocumentRange } from './phrase-token';
         .pdf-export-surface app-pdf-export-document {
           display: block;
         }
-
-        :host ::ng-deep .pdf-export-surface .pdf-export-document {
-          color: var(--composer-page-ink);
-          line-height: var(--composer-page-print-line-height);
-          white-space: pre-wrap;
-        }
-
-        :host ::ng-deep .pdf-export-surface .pdf-export-ruby,
-        :host ::ng-deep .pdf-export-surface .pdf-export-plain {
-          color: var(--composer-page-ink);
-          padding: 0 var(--composer-page-space-sm);
-        }
-
-        :host ::ng-deep .pdf-export-surface br {
-          display: block;
-        }
-
-        :host ::ng-deep .pdf-export-surface rt {
-          color: var(--composer-page-ink);
-          font-size: var(--composer-page-print-ruby-scale);
-          line-height: 1;
-          visibility: visible;
-        }
       }
     `,
   ],


### PR DESCRIPTION
## Summary
- Add a testable browser print service for the pinyin composer PDF export flow.
- Render PDF export content from full ordered document spans so plain text and newline breaks are preserved.
- Update the pinyin composer export surface and tests to preserve single/repeated newlines while keeping browser print-to-PDF.

## Verification
- `bazel run gazelle`
- `format`
- `aspect test //angular/projects/pinyin-composer:test`
- `aspect build //angular/projects/pinyin-composer:pinyin-composer`
- `aspect build //...`
- Browser smoke with `agent-browser`: confirmed `pdf-export-line-break`, enabled export, print stub count 1, and page remained loaded.