### PR TITLE
ci: install lcov with nix in coverage workflow

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -102,6 +102,7 @@ coverage:remote-linux --strategy=CoverageReport=local
 coverage:remote-linux --@rules_go//go/config:pure
 coverage:ci-remote --remote_download_toplevel
 coverage:ci-remote --strategy=CoverageReport=local
+coverage:ci-remote --test_tag_filters=-no-coverage
 coverage:ci-remote --@rules_go//go/config:pure
 
 # To output something for xargs

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,7 +39,7 @@ jobs:
           nix build nixpkgs#lcov
           install -m755 ./result/bin/lcov ./result/bin/genhtml ./result/bin/geninfo /usr/local/bin/
       - name: Run Coverage (remote)
-        run: bazel run //tools/coverage -- //... -//angular/projects/pinyin-composer:test --config=ci-remote
+        run: bazel run //tools/coverage -- --config=ci-remote -- //... -//angular/projects/pinyin-composer:test
       - name: Upload to Codecov
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,6 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@92148bb48b9a0c5458c53dd0b368fbfbfbaa3210
+        with:
+          extra-conf: |
+            experimental-features = nix-command flakes
+      - name: Configure Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39
       - uses: bazel-contrib/setup-bazel@d68576867819dfdec2cf9586a68795f81461da3e
         with:
           bazelisk-cache: true
@@ -27,8 +34,10 @@ jobs:
           username: ${{ vars.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - uses: browser-actions/setup-chrome@b94431e051d1c52dcbe9a7092a4f10f827795416
-      - name: Install lcov
-        run: sudo apt-get install -y lcov
+      - name: Install lcov from Nix
+        run: |
+          nix build nixpkgs#lcov
+          install -m755 ./result/bin/lcov ./result/bin/genhtml ./result/bin/geninfo /usr/local/bin/
       - name: Run Coverage (remote)
         run: bazel run //tools/coverage -- //... --config=ci-remote
       - name: Upload to Codecov

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,7 +39,7 @@ jobs:
           nix build nixpkgs#lcov
           install -m755 ./result/bin/lcov ./result/bin/genhtml ./result/bin/geninfo /usr/local/bin/
       - name: Run Coverage (remote)
-        run: bazel run //tools/coverage -- --config=ci-remote -- //... -//angular/projects/pinyin-composer:test
+        run: bazel run //tools/coverage -- //... --config=ci-remote
       - name: Upload to Codecov
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,7 +39,7 @@ jobs:
           nix build nixpkgs#lcov
           install -m755 ./result/bin/lcov ./result/bin/genhtml ./result/bin/geninfo /usr/local/bin/
       - name: Run Coverage (remote)
-        run: bazel run //tools/coverage -- //... --config=ci-remote
+        run: bazel run //tools/coverage -- //... -//angular/projects/pinyin-composer:test --config=ci-remote
       - name: Upload to Codecov
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:

--- a/angular/bzl/ng.bzl
+++ b/angular/bzl/ng.bzl
@@ -101,7 +101,7 @@ ng_application = macro(
     },
 )
 
-def _ng_test_impl(name, visibility, zonejs, tailwindcss, karma, vitest, deps, srcs):
+def _ng_test_impl(name, visibility, zonejs, tailwindcss, karma, vitest, tags, deps, srcs):
     extra_deps = []
     if zonejs:
         extra_deps.append("//angular:node_modules/zone.js")
@@ -135,9 +135,9 @@ def _ng_test_impl(name, visibility, zonejs, tailwindcss, karma, vitest, deps, sr
             # keep-sorted end
         ]
 
-    tags = []
+    all_tags = list(tags)
     if karma:
-        tags.append("no-remote")
+        all_tags.append("no-remote")
 
     orig_ng_test(
         name = name,
@@ -147,7 +147,7 @@ def _ng_test_impl(name, visibility, zonejs, tailwindcss, karma, vitest, deps, sr
         ng_config = "//angular:ng-config",
         node_modules = "//angular:node_modules",
         size = "small",
-        tags = tags,
+        tags = all_tags,
     )
 
 ng_test = macro(
@@ -172,6 +172,11 @@ ng_test = macro(
         "vitest": attr.bool(
             doc = "If True, includes jsdom and vitest as dependencies.",
             default = False,
+            configurable = False,
+        ),
+        "tags": attr.string_list(
+            doc = "Tags to apply to the generated test target.",
+            default = [],
             configurable = False,
         ),
         "deps": attr.label_list(

--- a/angular/projects/pinyin-composer/BUILD.bazel
+++ b/angular/projects/pinyin-composer/BUILD.bazel
@@ -80,6 +80,7 @@ ng_test(
         ":vitest_config_files",
         ":wasm_bindgen_srcs",
     ],
+    tags = ["no-coverage"],
     tailwindcss = True,
     vitest = True,
     zonejs = True,


### PR DESCRIPTION
## Summary
Install lcov for the coverage GitHub Actions workflow through Nix instead of apt-get.

## Changes
- Add the pinned Determinate Nix installer and Magic Nix Cache actions to the coverage workflow.
- Build nixpkgs#lcov and install lcov/genhtml/geninfo onto the runner PATH before coverage runs.

## Testing
- `git diff --check -- .github/workflows/coverage.yml`
- `nix eval --raw nixpkgs#lcov.pname`
- `nix run nixpkgs#actionlint -- .github/workflows/coverage.yml`