### PR TITLE
fix(pinyin-composer): support juede phrase conversion

### DIFF
--- a/pinyin-composer/wasm/src/converter.rs
+++ b/pinyin-composer/wasm/src/converter.rs
@@ -85,9 +85,10 @@ fn decode_ranked_candidates(
     syllables: &[String],
     limit: usize,
 ) -> Result<Vec<DecodedCandidate>, EngineError> {
-    let fast_candidates = decode_syllable_candidates(syllables, limit, 0);
+    let hmm = DefaultHmm::default();
+    let fast_candidates = decode_syllable_candidates(&hmm, syllables, limit, 0);
     let candidates = if fast_candidates.is_empty() {
-        exhaustive_split_candidates(normalized, limit)
+        exhaustive_split_candidates(&hmm, normalized, limit)
     } else {
         fast_candidates
     };
@@ -102,7 +103,11 @@ fn decode_ranked_candidates(
     Ok(candidates)
 }
 
-fn exhaustive_split_candidates(normalized: &str, limit: usize) -> Vec<DecodedCandidate> {
+fn exhaustive_split_candidates(
+    hmm: &DefaultHmm,
+    normalized: &str,
+    limit: usize,
+) -> Vec<DecodedCandidate> {
     let compact = normalized.split_whitespace().collect::<String>();
     if compact.len() > MAX_EXHAUSTIVE_SPLIT_INPUT_LEN {
         return Vec::new();
@@ -125,7 +130,7 @@ fn exhaustive_split_candidates(normalized: &str, limit: usize) -> Vec<DecodedCan
     let mut candidates = variants
         .iter()
         .flat_map(|(variant_order, syllables)| {
-            decode_syllable_candidates(syllables, limit, *variant_order)
+            decode_syllable_candidates(hmm, syllables, limit, *variant_order)
         })
         .collect::<Vec<_>>();
 
@@ -134,7 +139,7 @@ fn exhaustive_split_candidates(normalized: &str, limit: usize) -> Vec<DecodedCan
         .any(|candidate| candidate.hanzi.contains("觉得"))
     {
         candidates.extend(variants.iter().flat_map(|(variant_order, syllables)| {
-            juede_safety_candidates(syllables, *variant_order)
+            juede_safety_candidates(hmm, syllables, *variant_order)
         }));
     }
 
@@ -142,14 +147,14 @@ fn exhaustive_split_candidates(normalized: &str, limit: usize) -> Vec<DecodedCan
 }
 
 fn decode_syllable_candidates(
+    hmm: &DefaultHmm,
     syllables: &[String],
     limit: usize,
     variant_order: usize,
 ) -> Vec<DecodedCandidate> {
     let syllable_refs = syllables.iter().map(String::as_str).collect::<Vec<_>>();
 
-    let hmm = DefaultHmm::default();
-    viterbi(&hmm, &syllable_refs, limit, false, 3.14e-200)
+    viterbi(hmm, &syllable_refs, limit, false, 3.14e-200)
         .into_iter()
         .map(|candidate| DecodedCandidate {
             hanzi: candidate.path().iter().collect(),
@@ -159,14 +164,18 @@ fn decode_syllable_candidates(
         .collect::<Vec<_>>()
 }
 
-fn juede_safety_candidates(syllables: &[String], variant_order: usize) -> Vec<DecodedCandidate> {
+fn juede_safety_candidates(
+    hmm: &DefaultHmm,
+    syllables: &[String],
+    variant_order: usize,
+) -> Vec<DecodedCandidate> {
     syllables
         .windows(2)
         .enumerate()
         .filter(|(_, window)| window[0] == "jue" && window[1] == "de")
         .filter_map(|(index, _)| {
-            let (prefix_hanzi, prefix_score) = decode_best_hanzi(&syllables[..index])?;
-            let (suffix_hanzi, suffix_score) = decode_best_hanzi(&syllables[index + 2..])?;
+            let (prefix_hanzi, prefix_score) = decode_best_hanzi(hmm, &syllables[..index])?;
+            let (suffix_hanzi, suffix_score) = decode_best_hanzi(hmm, &syllables[index + 2..])?;
             let score = if prefix_hanzi.is_empty() && suffix_hanzi.is_empty() {
                 1.0
             } else {
@@ -182,12 +191,12 @@ fn juede_safety_candidates(syllables: &[String], variant_order: usize) -> Vec<De
         .collect()
 }
 
-fn decode_best_hanzi(syllables: &[String]) -> Option<(String, f64)> {
+fn decode_best_hanzi(hmm: &DefaultHmm, syllables: &[String]) -> Option<(String, f64)> {
     if syllables.is_empty() {
         return Some((String::new(), 1.0));
     }
 
-    decode_syllable_candidates(syllables, 1, 0)
+    decode_syllable_candidates(hmm, syllables, 1, 0)
         .into_iter()
         .next()
         .map(|candidate| (candidate.hanzi, candidate.score))

--- a/pinyin-composer/wasm/src/converter.rs
+++ b/pinyin-composer/wasm/src/converter.rs
@@ -1,5 +1,9 @@
+use std::cmp::Ordering;
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
+
 use pinyinchch::hmm::viterbi;
-use pinyinchch::pinyin::pinyin_split_by_trie_tokenizer;
+use pinyinchch::pinyin::{pinyin_split, pinyin_split_by_trie_tokenizer};
 use pinyinchch_model_hmm::DefaultHmm;
 
 use crate::annotator::annotate_phrase;
@@ -7,6 +11,8 @@ use crate::error::EngineError;
 use crate::model::{Candidate, ConversionResult};
 
 const MAX_CANDIDATE_LIMIT: usize = 20;
+const MAX_EXHAUSTIVE_SPLIT_INPUT_LEN: usize = 32;
+const MAX_EXHAUSTIVE_SPLIT_VARIANTS: usize = 64;
 
 pub fn convert_pinyin(source_pinyin: &str, limit: usize) -> Result<ConversionResult, EngineError> {
     let normalized = normalize_pinyin_input(source_pinyin)?;
@@ -15,11 +21,8 @@ pub fn convert_pinyin(source_pinyin: &str, limit: usize) -> Result<ConversionRes
     }
 
     let source_pinyin_syllables = syllables_from_normalized_pinyin(&normalized)?;
-    let decoded = decode_ranked_candidates(
-        &normalized,
-        &source_pinyin_syllables,
-        limit.min(MAX_CANDIDATE_LIMIT),
-    )?;
+    let capped_limit = limit.min(MAX_CANDIDATE_LIMIT);
+    let decoded = decode_ranked_candidates(&normalized, &source_pinyin_syllables, capped_limit)?;
     let candidates = decoded
         .into_iter()
         .enumerate()
@@ -46,6 +49,7 @@ pub fn convert_pinyin(source_pinyin: &str, limit: usize) -> Result<ConversionRes
 struct DecodedCandidate {
     hanzi: String,
     score: f64,
+    variant_order: usize,
 }
 
 fn normalize_pinyin_input(source_pinyin: &str) -> Result<String, EngineError> {
@@ -81,16 +85,13 @@ fn decode_ranked_candidates(
     syllables: &[String],
     limit: usize,
 ) -> Result<Vec<DecodedCandidate>, EngineError> {
-    let syllable_refs = syllables.iter().map(String::as_str).collect::<Vec<_>>();
-
-    let hmm = DefaultHmm::default();
-    let candidates = viterbi(&hmm, &syllable_refs, limit, false, 3.14e-200)
-        .into_iter()
-        .map(|candidate| DecodedCandidate {
-            hanzi: candidate.path().iter().collect(),
-            score: candidate.score(),
-        })
-        .collect::<Vec<_>>();
+    let fast_candidates = decode_syllable_candidates(syllables, limit, 0);
+    let candidates = if fast_candidates.is_empty() {
+        exhaustive_split_candidates(normalized, limit)
+    } else {
+        fast_candidates
+    };
+    let candidates = dedupe_and_rank_candidates(candidates, limit);
 
     if candidates.is_empty() {
         return Err(EngineError::ConversionUnavailable(format!(
@@ -99,4 +100,133 @@ fn decode_ranked_candidates(
     }
 
     Ok(candidates)
+}
+
+fn exhaustive_split_candidates(normalized: &str, limit: usize) -> Vec<DecodedCandidate> {
+    let compact = normalized.split_whitespace().collect::<String>();
+    if compact.len() > MAX_EXHAUSTIVE_SPLIT_INPUT_LEN {
+        return Vec::new();
+    }
+
+    let variants = pinyin_split(&compact);
+    let variants = variants
+        .into_iter()
+        .take(MAX_EXHAUSTIVE_SPLIT_VARIANTS)
+        .enumerate()
+        .map(|(variant_order, variant)| {
+            let syllables = variant
+                .split_whitespace()
+                .map(|syllable| syllable.to_string())
+                .collect::<Vec<_>>();
+            (variant_order, syllables)
+        })
+        .collect::<Vec<_>>();
+
+    let mut candidates = variants
+        .iter()
+        .flat_map(|(variant_order, syllables)| {
+            decode_syllable_candidates(syllables, limit, *variant_order)
+        })
+        .collect::<Vec<_>>();
+
+    if !candidates
+        .iter()
+        .any(|candidate| candidate.hanzi.contains("觉得"))
+    {
+        candidates.extend(variants.iter().flat_map(|(variant_order, syllables)| {
+            juede_safety_candidates(syllables, *variant_order)
+        }));
+    }
+
+    candidates
+}
+
+fn decode_syllable_candidates(
+    syllables: &[String],
+    limit: usize,
+    variant_order: usize,
+) -> Vec<DecodedCandidate> {
+    let syllable_refs = syllables.iter().map(String::as_str).collect::<Vec<_>>();
+
+    let hmm = DefaultHmm::default();
+    viterbi(&hmm, &syllable_refs, limit, false, 3.14e-200)
+        .into_iter()
+        .map(|candidate| DecodedCandidate {
+            hanzi: candidate.path().iter().collect(),
+            score: candidate.score(),
+            variant_order,
+        })
+        .collect::<Vec<_>>()
+}
+
+fn juede_safety_candidates(syllables: &[String], variant_order: usize) -> Vec<DecodedCandidate> {
+    syllables
+        .windows(2)
+        .enumerate()
+        .filter(|(_, window)| window[0] == "jue" && window[1] == "de")
+        .filter_map(|(index, _)| {
+            let (prefix_hanzi, prefix_score) = decode_best_hanzi(&syllables[..index])?;
+            let (suffix_hanzi, suffix_score) = decode_best_hanzi(&syllables[index + 2..])?;
+            let score = if prefix_hanzi.is_empty() && suffix_hanzi.is_empty() {
+                1.0
+            } else {
+                prefix_score * suffix_score
+            };
+
+            Some(DecodedCandidate {
+                hanzi: format!("{prefix_hanzi}觉得{suffix_hanzi}"),
+                score,
+                variant_order,
+            })
+        })
+        .collect()
+}
+
+fn decode_best_hanzi(syllables: &[String]) -> Option<(String, f64)> {
+    if syllables.is_empty() {
+        return Some((String::new(), 1.0));
+    }
+
+    decode_syllable_candidates(syllables, 1, 0)
+        .into_iter()
+        .next()
+        .map(|candidate| (candidate.hanzi, candidate.score))
+}
+
+fn dedupe_and_rank_candidates(
+    candidates: Vec<DecodedCandidate>,
+    limit: usize,
+) -> Vec<DecodedCandidate> {
+    let mut best_by_hanzi = HashMap::new();
+
+    for candidate in candidates {
+        match best_by_hanzi.entry(candidate.hanzi.clone()) {
+            Entry::Vacant(entry) => {
+                entry.insert(candidate);
+            }
+            Entry::Occupied(mut entry) => {
+                if is_better_candidate(&candidate, entry.get()) {
+                    entry.insert(candidate);
+                }
+            }
+        }
+    }
+
+    let mut candidates = best_by_hanzi.into_values().collect::<Vec<_>>();
+    candidates.sort_by(compare_candidates);
+    candidates.truncate(limit);
+    candidates
+}
+
+fn is_better_candidate(candidate: &DecodedCandidate, current: &DecodedCandidate) -> bool {
+    compare_candidates(candidate, current).is_lt()
+}
+
+fn compare_candidates(left: &DecodedCandidate, right: &DecodedCandidate) -> Ordering {
+    right
+        .score
+        .partial_cmp(&left.score)
+        .unwrap_or(Ordering::Equal)
+        .then_with(|| left.variant_order.cmp(&right.variant_order))
+        .then_with(|| left.hanzi.cmp(&right.hanzi))
 }

--- a/pinyin-composer/wasm/tests/conversion_tests.rs
+++ b/pinyin-composer/wasm/tests/conversion_tests.rs
@@ -22,6 +22,46 @@ fn convert_pinyin_returns_ranked_phrase_candidates() {
 }
 
 #[test]
+fn convert_pinyin_accepts_juede() {
+    let result = convert_pinyin("juede", 5).expect("juede conversion succeeds");
+
+    assert_eq!(result.source_pinyin, "juede");
+    assert!(!result.candidates.is_empty());
+    assert!(
+        result
+            .candidates
+            .iter()
+            .any(|candidate| candidate.hanzi == "觉得")
+    );
+}
+
+#[test]
+fn convert_pinyin_accepts_spaced_jue_de_phrase() {
+    let result = convert_pinyin("wo jue de", 5).expect("wo jue de conversion succeeds");
+
+    assert_eq!(result.source_pinyin, "wo jue de");
+    assert!(
+        result
+            .candidates
+            .iter()
+            .any(|candidate| candidate.hanzi.contains("觉得"))
+    );
+}
+
+#[test]
+fn convert_pinyin_accepts_compact_juede_phrase_block() {
+    let result = convert_pinyin("wo juede", 5).expect("wo juede conversion succeeds");
+
+    assert_eq!(result.source_pinyin, "wo juede");
+    assert!(
+        result
+            .candidates
+            .iter()
+            .any(|candidate| candidate.hanzi.contains("觉得"))
+    );
+}
+
+#[test]
 fn convert_pinyin_clamps_large_candidate_limit() {
     let result = convert_pinyin("chi fan", 10_000).expect("conversion succeeds");
 


### PR DESCRIPTION
## Summary
Fixes pinyin composer conversion for `juede` and phrase/block inputs like `wo jue de` and `wo juede`.

## Changes
- Adds exhaustive compact pinyin split fallback after the fast HMM decode path returns no candidates.
- Keeps a narrow `jue de` safety composition because the bundled HMM does not emit `觉得` for that syllable pair by itself.
- Adds Rust/WASM regression coverage for exact, spaced phrase, and compact phrase-block inputs.

## Testing
- `bazel run gazelle`
- `format`
- `aspect test //pinyin-composer/wasm:wasm_tests`
- `aspect build //angular/projects/pinyin-composer:pinyin-composer`

## Notes
Local dev server was started for manual testing at `http://localhost:4200/` from the feature worktree.