### PR TITLE
refactor(pinyin-composer): generalize mistakable word matching

### DIFF
--- a/pinyin-composer/wasm/src/converter.rs
+++ b/pinyin-composer/wasm/src/converter.rs
@@ -144,11 +144,17 @@ fn exhaustive_split_candidates(
         })
         .collect::<Vec<_>>();
 
-    if !candidates_contain_mistakable_word(&candidates) {
-        candidates.extend(variants.iter().flat_map(|(variant_order, syllables)| {
-            mistakable_word_candidates(hmm, syllables, *variant_order)
-        }));
-    }
+    let mistakable_candidates = MISTAKABLE_WORDS
+        .iter()
+        .filter(|entry| !candidates_contain_mistakable_word(&candidates, entry))
+        .flat_map(|entry| {
+            variants.iter().flat_map(move |(variant_order, syllables)| {
+                mistakable_word_candidates(hmm, entry, syllables, *variant_order)
+            })
+        })
+        .collect::<Vec<_>>();
+
+    candidates.extend(mistakable_candidates);
 
     candidates
 }
@@ -171,43 +177,45 @@ fn decode_syllable_candidates(
         .collect::<Vec<_>>()
 }
 
-fn candidates_contain_mistakable_word(candidates: &[DecodedCandidate]) -> bool {
-    MISTAKABLE_WORDS.iter().any(|entry| {
-        candidates
-            .iter()
-            .any(|candidate| candidate.hanzi.contains(entry.hanzi))
-    })
+fn candidates_contain_mistakable_word(
+    candidates: &[DecodedCandidate],
+    entry: &MistakableWord,
+) -> bool {
+    candidates
+        .iter()
+        .any(|candidate| candidate.hanzi.contains(entry.hanzi))
 }
 
 fn mistakable_word_candidates(
     hmm: &DefaultHmm,
+    entry: &MistakableWord,
     syllables: &[String],
     variant_order: usize,
 ) -> Vec<DecodedCandidate> {
-    MISTAKABLE_WORDS
-        .iter()
-        .flat_map(|entry| {
-            syllables
-                .windows(entry.syllables.len())
-                .enumerate()
-                .filter(|(_, window)| mistakable_syllable_window_matches(window, entry.syllables))
-                .filter_map(|(index, _)| {
-                    let (prefix_hanzi, prefix_score) = decode_best_hanzi(hmm, &syllables[..index])?;
-                    let suffix_start = index + entry.syllables.len();
-                    let (suffix_hanzi, suffix_score) =
-                        decode_best_hanzi(hmm, &syllables[suffix_start..])?;
-                    let score = if prefix_hanzi.is_empty() && suffix_hanzi.is_empty() {
-                        1.0
-                    } else {
-                        prefix_score * suffix_score
-                    };
+    assert!(
+        !entry.syllables.is_empty(),
+        "mistakable word entry must contain at least one syllable"
+    );
 
-                    Some(DecodedCandidate {
-                        hanzi: format!("{prefix_hanzi}{}{suffix_hanzi}", entry.hanzi),
-                        score,
-                        variant_order,
-                    })
-                })
+    syllables
+        .windows(entry.syllables.len())
+        .enumerate()
+        .filter(|(_, window)| mistakable_syllable_window_matches(window, entry.syllables))
+        .filter_map(|(index, _)| {
+            let (prefix_hanzi, prefix_score) = decode_best_hanzi(hmm, &syllables[..index])?;
+            let suffix_start = index + entry.syllables.len();
+            let (suffix_hanzi, suffix_score) = decode_best_hanzi(hmm, &syllables[suffix_start..])?;
+            let score = if prefix_hanzi.is_empty() && suffix_hanzi.is_empty() {
+                1.0
+            } else {
+                prefix_score * suffix_score
+            };
+
+            Some(DecodedCandidate {
+                hanzi: format!("{prefix_hanzi}{}{suffix_hanzi}", entry.hanzi),
+                score,
+                variant_order,
+            })
         })
         .collect()
 }
@@ -266,4 +274,35 @@ fn compare_candidates(left: &DecodedCandidate, right: &DecodedCandidate) -> Orde
         .unwrap_or(Ordering::Equal)
         .then_with(|| left.variant_order.cmp(&right.variant_order))
         .then_with(|| left.hanzi.cmp(&right.hanzi))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DecodedCandidate, MistakableWord, candidates_contain_mistakable_word};
+
+    #[test]
+    fn candidates_contain_mistakable_word_checks_one_entry() {
+        let present_entry = MistakableWord {
+            syllables: &["jue", "de"],
+            hanzi: "觉得",
+        };
+        let missing_entry = MistakableWord {
+            syllables: &["yi", "wei"],
+            hanzi: "以为",
+        };
+        let candidates = [DecodedCandidate {
+            hanzi: "我觉得".to_string(),
+            score: 1.0,
+            variant_order: 0,
+        }];
+
+        assert!(candidates_contain_mistakable_word(
+            &candidates,
+            &present_entry
+        ));
+        assert!(!candidates_contain_mistakable_word(
+            &candidates,
+            &missing_entry
+        ));
+    }
 }

--- a/pinyin-composer/wasm/src/converter.rs
+++ b/pinyin-composer/wasm/src/converter.rs
@@ -14,6 +14,16 @@ const MAX_CANDIDATE_LIMIT: usize = 20;
 const MAX_EXHAUSTIVE_SPLIT_INPUT_LEN: usize = 32;
 const MAX_EXHAUSTIVE_SPLIT_VARIANTS: usize = 64;
 
+struct MistakableWord {
+    syllables: &'static [&'static str],
+    hanzi: &'static str,
+}
+
+static MISTAKABLE_WORDS: &[MistakableWord] = &[MistakableWord {
+    syllables: &["jue", "de"],
+    hanzi: "觉得",
+}];
+
 pub fn convert_pinyin(source_pinyin: &str, limit: usize) -> Result<ConversionResult, EngineError> {
     let normalized = normalize_pinyin_input(source_pinyin)?;
     if limit == 0 {
@@ -134,12 +144,9 @@ fn exhaustive_split_candidates(
         })
         .collect::<Vec<_>>();
 
-    if !candidates
-        .iter()
-        .any(|candidate| candidate.hanzi.contains("觉得"))
-    {
+    if !candidates_contain_mistakable_word(&candidates) {
         candidates.extend(variants.iter().flat_map(|(variant_order, syllables)| {
-            juede_safety_candidates(hmm, syllables, *variant_order)
+            mistakable_word_candidates(hmm, syllables, *variant_order)
         }));
     }
 
@@ -164,31 +171,52 @@ fn decode_syllable_candidates(
         .collect::<Vec<_>>()
 }
 
-fn juede_safety_candidates(
+fn candidates_contain_mistakable_word(candidates: &[DecodedCandidate]) -> bool {
+    MISTAKABLE_WORDS.iter().any(|entry| {
+        candidates
+            .iter()
+            .any(|candidate| candidate.hanzi.contains(entry.hanzi))
+    })
+}
+
+fn mistakable_word_candidates(
     hmm: &DefaultHmm,
     syllables: &[String],
     variant_order: usize,
 ) -> Vec<DecodedCandidate> {
-    syllables
-        .windows(2)
-        .enumerate()
-        .filter(|(_, window)| window[0] == "jue" && window[1] == "de")
-        .filter_map(|(index, _)| {
-            let (prefix_hanzi, prefix_score) = decode_best_hanzi(hmm, &syllables[..index])?;
-            let (suffix_hanzi, suffix_score) = decode_best_hanzi(hmm, &syllables[index + 2..])?;
-            let score = if prefix_hanzi.is_empty() && suffix_hanzi.is_empty() {
-                1.0
-            } else {
-                prefix_score * suffix_score
-            };
+    MISTAKABLE_WORDS
+        .iter()
+        .flat_map(|entry| {
+            syllables
+                .windows(entry.syllables.len())
+                .enumerate()
+                .filter(|(_, window)| mistakable_syllable_window_matches(window, entry.syllables))
+                .filter_map(|(index, _)| {
+                    let (prefix_hanzi, prefix_score) = decode_best_hanzi(hmm, &syllables[..index])?;
+                    let suffix_start = index + entry.syllables.len();
+                    let (suffix_hanzi, suffix_score) =
+                        decode_best_hanzi(hmm, &syllables[suffix_start..])?;
+                    let score = if prefix_hanzi.is_empty() && suffix_hanzi.is_empty() {
+                        1.0
+                    } else {
+                        prefix_score * suffix_score
+                    };
 
-            Some(DecodedCandidate {
-                hanzi: format!("{prefix_hanzi}觉得{suffix_hanzi}"),
-                score,
-                variant_order,
-            })
+                    Some(DecodedCandidate {
+                        hanzi: format!("{prefix_hanzi}{}{suffix_hanzi}", entry.hanzi),
+                        score,
+                        variant_order,
+                    })
+                })
         })
         .collect()
+}
+
+fn mistakable_syllable_window_matches(window: &[String], entry_syllables: &[&str]) -> bool {
+    window
+        .iter()
+        .map(String::as_str)
+        .eq(entry_syllables.iter().copied())
 }
 
 fn decode_best_hanzi(hmm: &DefaultHmm, syllables: &[String]) -> Option<(String, f64)> {

--- a/pinyin-composer/wasm/tests/conversion_tests.rs
+++ b/pinyin-composer/wasm/tests/conversion_tests.rs
@@ -74,7 +74,7 @@ fn convert_pinyin_accepts_sentence_context_wo_jue_de() {
 }
 
 #[test]
-fn convert_pinyin_rejects_unrelated_input_without_juede() {
+fn convert_pinyin_does_not_inject_juede_for_unrelated_input() {
     let result = convert_pinyin("wo qu le", 5).expect("wo qu le conversion succeeds");
 
     assert_eq!(result.source_pinyin, "wo qu le");

--- a/pinyin-composer/wasm/tests/conversion_tests.rs
+++ b/pinyin-composer/wasm/tests/conversion_tests.rs
@@ -22,11 +22,10 @@ fn convert_pinyin_returns_ranked_phrase_candidates() {
 }
 
 #[test]
-fn convert_pinyin_accepts_juede() {
+fn convert_pinyin_accepts_joined_juede() {
     let result = convert_pinyin("juede", 5).expect("juede conversion succeeds");
 
     assert_eq!(result.source_pinyin, "juede");
-    assert!(!result.candidates.is_empty());
     assert!(
         result
             .candidates
@@ -36,7 +35,33 @@ fn convert_pinyin_accepts_juede() {
 }
 
 #[test]
-fn convert_pinyin_accepts_spaced_jue_de_phrase() {
+fn convert_pinyin_accepts_spaced_jue_de() {
+    let result = convert_pinyin("jue de", 5).expect("jue de conversion succeeds");
+
+    assert_eq!(result.source_pinyin, "jue de");
+    assert!(
+        result
+            .candidates
+            .iter()
+            .any(|candidate| candidate.hanzi == "觉得")
+    );
+}
+
+#[test]
+fn convert_pinyin_accepts_sentence_context_wo_juede() {
+    let result = convert_pinyin("wo juede", 5).expect("wo juede conversion succeeds");
+
+    assert_eq!(result.source_pinyin, "wo juede");
+    assert!(
+        result
+            .candidates
+            .iter()
+            .any(|candidate| candidate.hanzi.contains("觉得"))
+    );
+}
+
+#[test]
+fn convert_pinyin_accepts_sentence_context_wo_jue_de() {
     let result = convert_pinyin("wo jue de", 5).expect("wo jue de conversion succeeds");
 
     assert_eq!(result.source_pinyin, "wo jue de");
@@ -49,16 +74,28 @@ fn convert_pinyin_accepts_spaced_jue_de_phrase() {
 }
 
 #[test]
-fn convert_pinyin_accepts_compact_juede_phrase_block() {
-    let result = convert_pinyin("wo juede", 5).expect("wo juede conversion succeeds");
+fn convert_pinyin_rejects_unrelated_input_without_juede() {
+    let result = convert_pinyin("wo qu le", 5).expect("wo qu le conversion succeeds");
 
-    assert_eq!(result.source_pinyin, "wo juede");
+    assert_eq!(result.source_pinyin, "wo qu le");
     assert!(
         result
             .candidates
             .iter()
-            .any(|candidate| candidate.hanzi.contains("觉得"))
+            .all(|candidate| !candidate.hanzi.contains("觉得"))
     );
+}
+
+#[test]
+fn convert_pinyin_deduplicates_juede_candidate() {
+    let result = convert_pinyin("wo jue de", 20).expect("wo jue de conversion succeeds");
+    let juede_count = result
+        .candidates
+        .iter()
+        .filter(|candidate| candidate.hanzi.contains("觉得"))
+        .count();
+
+    assert!(juede_count <= 1);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- replace the hardcoded juede safety candidate path with a configurable mistakable-word table
- keep the current jue/de -> 觉得 behavior while making future entries data-driven
- add regression coverage for joined, spaced, contextual, unrelated, and dedupe cases

## Verification
- bazel run gazelle
- format
- aspect test //pinyin-composer/wasm:wasm_tests
- aspect test //angular/projects/pinyin-composer:test
- aspect build //angular/projects/pinyin-composer:pinyin-composer
- aspect build --bazel-flag=--keep_going //...