### PR TITLE
ci: activate lint Bazel config in Aspect

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -1,7 +1,12 @@
 load("@aspect//traits.axl", "BazelTrait")
 
+def _lint_bazel_flags(ctx):
+    if ctx.task.name == "lint":
+        return ["--config=lint"]
+    return []
+
 def config(ctx):
-    ctx.traits[BazelTrait].extra_flags.append("--build_tag_filters=-no-lint")
+    ctx.traits[BazelTrait].task_flags.append(_lint_bazel_flags)
     ctx.tasks["lint"].args.aspects = [
         "//tools/lint:linters.bzl%buf",
         "//tools/lint:linters.bzl%eslint",

--- a/.bazelrc
+++ b/.bazelrc
@@ -70,18 +70,6 @@ common:release --stamp --workspace_status_command=./tools/workspace_status.sh
 # see https://github.com/bazelbuild/rules_jvm_external/issues/445
 build --repo_env=JAVA_HOME=../bazel_tools/jdk
 
-# Linting configuration
-common:lint --aspects=//tools/lint:linters.bzl%buf
-common:lint --aspects=//tools/lint:linters.bzl%checkstyle
-common:lint --aspects=//tools/lint:linters.bzl%eslint
-common:lint --aspects=//tools/lint:linters.bzl%shellcheck
-common:lint --aspects=//tools/lint:linters.bzl%ruff
-common:lint --aspects=//tools/lint:linters.bzl%pmd
-common:lint --aspects=//tools/lint:linters.bzl%ktlint
-common:lint --aspects=//tools/lint:linters.bzl%keep_sorted
-common:lint --aspects=//tools/lint:linters.bzl%stylelint
-common:lint --aspects=//tools/lint:linters.bzl%clippy
-
 # Show timeout warnings to correctly adjust build/test timeouts
 test --test_verbose_timeout_warnings
 # Pass CHROME_BIN from the host environment into the Bazel test sandbox


### PR DESCRIPTION
## Summary
- make `aspect lint` pass `--config=lint` so CI-injected `common:lint` settings apply
- remove duplicate `common:lint --aspects` entries from `.bazelrc` because Aspect config already provides the linter aspect list

## Validation
- `aspect lint //tools/lint:linters --announce-rc=true --strategy=soft`
- `format`