### PR TITLE
refactor: Update build scan blog title

### DIFF
--- a/personal_website/src/content/blog/local-first-gradle-build-scan.md
+++ b/personal_website/src/content/blog/local-first-gradle-build-scan.md
@@ -1,12 +1,12 @@
 ---
-title: "Self-Hosted Gradle Build Scans with LowkeyLab"
-description: "A technical tour of gradle-build-scan-server: a self-hosted way to collect, inspect, and learn from Gradle build scans."
+title: "Local-First Gradle Build Scan"
+description: "A technical tour of gradle-build-scan-server: a local-first way to collect, inspect, and learn from Gradle build scans."
 publishDate: 2026-05-27
 tags: ["gradle", "build-tools", "rust", "angular", "observability"]
 draft: false
 ---
 
-# Self-Hosted Gradle Build Scans
+# Local-First Gradle Build Scan
 
 Gradle offers
 [remote build scans](https://docs.gradle.org/current/userguide/inspect.html)
@@ -25,7 +25,7 @@ needing to stream my build over the internet to the public endpoint.
 Privacy-oriented developers would also have the same need.
 
 So, I decided to write a
-[self-hosted Gradle Build Scan server](https://github.com/LowkeyLab/gradle-build-scan-server)
+[local-first Gradle Build Scan server](https://github.com/LowkeyLab/gradle-build-scan-server)
 that tries its best to capture important information about your Gradle build.
 
 ## What It Is

--- a/personal_website/src/content/projects/gradle-build-scan-server.md
+++ b/personal_website/src/content/projects/gradle-build-scan-server.md
@@ -1,21 +1,21 @@
 ---
 title: "Gradle Build Scan Server"
-description: "A self-hosted server for collecting and inspecting Gradle build scans"
+description: "A local-first server for collecting and inspecting Gradle build scans"
 tags: ["Gradle", "Rust", "Angular", "Bazel", "Build Tools"]
 startDate: 2026-05-27
 featured: false
 links:
   github: "https://github.com/LowkeyLab/gradle-build-scan-server"
-  website: "/blog/self-hosted-gradle-build-scans"
+  website: "/blog/local-first-gradle-build-scan"
 ---
 
 ## Overview
 
-Gradle Build Scan Server is a self-hosted server for collecting and inspecting Gradle build scans without sending them to the public scan endpoint.
+Gradle Build Scan Server is a local-first server for collecting and inspecting Gradle build scans without sending them to the public scan endpoint.
 
-I wrote a longer post about why I built it and what it can inspect: [Self-Hosted Gradle Build Scans](/blog/self-hosted-gradle-build-scans).
+I wrote a longer post about why I built it and what it can inspect: [Local-First Gradle Build Scan](/blog/local-first-gradle-build-scan).
 
 ## Links
 
-- [Read the blog post](/blog/self-hosted-gradle-build-scans)
+- [Read the blog post](/blog/local-first-gradle-build-scan)
 - [View the source on GitHub](https://github.com/LowkeyLab/gradle-build-scan-server)


### PR DESCRIPTION
## Summary
- Rename the build scan blog slug and title to Local-First Gradle Build Scan
- Remove the LowkeyLab suffix from the blog title
- Update project links and descriptions to use local-first wording

## Validation
- bazel run gazelle
- format
- aspect build //personal_website:build