### PR TITLE
chore: update repo to Java 25

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,6 @@
 # Import bazelrc presets
 import %workspace%/tools/preset.bazelrc
-try-import %workspace%/tools/java21.bazelrc
+try-import %workspace%/tools/java25.bazelrc
 
 ### YOUR PROJECT SPECIFIC OPTIONS GO HERE ###
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -101,7 +101,7 @@ gazelle_binary(
 ### Kotlin toolchain configuration
 define_kt_toolchain(
     name = "kotlin_toolchain",
-    jvm_target = "21",
+    jvm_target = "25",
 )
 
 ### Rust project generation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ Polyglot monorepo with independent backend services and Angular frontends, all b
 | -------------------- | ------------------- | ----------------------------------------------- | ---------------------------- |
 | **nicknamer**        | `nicknamer/`        | Rust, Axum, SeaORM, PostgreSQL                  | REST API with Swagger/utoipa |
 | **nicknamer2**       | `nicknamer2/`       | Rust, Axum, Juniper (GraphQL), sqlx, PostgreSQL | Relay-style pagination       |
-| **mindreadr**        | `mindreadr/`        | Kotlin, Ktor 3, Exposed, JVM 21                 |                              |
+| **mindreadr**        | `mindreadr/`        | Kotlin, Ktor 3, Exposed, JVM 25                 |                              |
 | **predix**           | `predix/`           | Go, Gin, pgx, sqlc                              |                              |
 | **cowsay**           | `cowsay/`           | Go                                              | Demo service                 |
 | **personal_website** | `personal_website/` | Astro 5, Caddy                                  | Static site                  |

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -449,9 +449,9 @@ oci_extension.pull(
     ],
 )
 oci_extension.pull(
-    name = "distroless_java21",
-    digest = "sha256:46918c99fec3a4fb69c5e6d0679883935997f63ad602165369795039875384b0",
-    image = "gcr.io/distroless/java21-debian13",
+    name = "distroless_java25",
+    digest = "sha256:583ba2e08558063002bd1b5874a81b33b7204a0ad46727d4b6cbeff5a25935ba",
+    image = "gcr.io/distroless/java25-debian13",
     platforms = [
         "linux/amd64",
     ],
@@ -472,7 +472,7 @@ oci_extension.pull(
         "linux/amd64",
     ],
 )
-use_repo(oci_extension, "alpine_caddy", "alpine_caddy_linux_amd64", "distroless_cc", "distroless_cc_linux_amd64", "distroless_java21", "distroless_java21_linux_amd64", "distroless_node24", "distroless_node24_linux_amd64")
+use_repo(oci_extension, "alpine_caddy", "alpine_caddy_linux_amd64", "distroless_cc", "distroless_cc_linux_amd64", "distroless_java25", "distroless_java25_linux_amd64", "distroless_node24", "distroless_node24_linux_amd64")
 
 ###########################
 # BuildBuddy Remote Execution

--- a/flake.nix
+++ b/flake.nix
@@ -83,7 +83,7 @@
               pkgs.prettier
               pkgs.go
               pkgs.pnpm
-              pkgs.jdk21_headless
+              pkgs.jdk25_headless
               pkgs.gcc
               pkgs.pre-commit
               agent-browser
@@ -97,7 +97,7 @@
             # Linux: set NIX_LD so bazelisk can run downloaded Bazel binaries
             # On NixOS, this additionally requires `programs.nix-ld.enable = true`
             env = {
-              JAVA_HOME = "${pkgs.jdk21_headless}";
+              JAVA_HOME = "${pkgs.jdk25_headless}";
             } // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
               NIX_LD = pkgs.stdenv.cc.bintools.dynamicLinker;
               NIX_LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [

--- a/mindreadr/src/main/io/lowkeylab/mindreadr/app/BUILD.bazel
+++ b/mindreadr/src/main/io/lowkeylab/mindreadr/app/BUILD.bazel
@@ -43,7 +43,7 @@ pkg_tar(
 
 oci_image(
     name = "app_image",
-    base = "@distroless_java21",
+    base = "@distroless_java25",
     entrypoint = [
         "java",
         "-jar",

--- a/tools/java25.bazelrc
+++ b/tools/java25.bazelrc
@@ -4,17 +4,17 @@
 
 # What version of Java are the source files in this repo?
 # See https://bazel.build/docs/user-manual#java-language-version
-common --java_language_version=21
+common --java_language_version=25
 
 # The Java language version used to build tools that are executed during a build
 # See https://bazel.build/docs/user-manual#tool-java-language-version
-common --tool_java_language_version=21
+common --tool_java_language_version=25
 
 # The version of JVM to use to execute the code and run the tests.
 # NB: The default value is local_jdk which is non-hermetic.
 # See https://bazel.build/docs/user-manual#java-runtime-version
-common --java_runtime_version=remotejdk_21
+common --java_runtime_version=remotejdk_25
 
 # The version of JVM used to execute tools that are needed during a build.
 # See https://bazel.build/docs/user-manual#tool-java-runtime-version
-common --tool_java_runtime_version=remotejdk_21
+common --tool_java_runtime_version=remotejdk_25


### PR DESCRIPTION
## Summary

- update Bazel Java policy from Java 21 to Java 25 (`remotejdk_25`)
- update Kotlin JVM target and Nix dev shell JDK to Java 25
- switch Mindreadr's Java distroless base to `gcr.io/distroless/java25-debian13`
- update JVM baseline docs to JVM 25

## Distroless digest

Pinned `gcr.io/distroless/java25-debian13` to registry digest:

`sha256:583ba2e08558063002bd1b5874a81b33b7204a0ad46727d4b6cbeff5a25935ba`

Digest source was the `docker-content-digest` header from the GCR registry manifest endpoint.

## Validation

Passed:

- `bazel run gazelle` (passed on rerun; emitted Java 25 Unsafe deprecation warnings from Netty)
- `format` (passed; emitted Java 25 Unsafe deprecation warnings from Kotlin tooling)
- `git diff --check`
- stale Java 21 reference search
- `nix-instantiate --parse flake.nix`
- `bazel test //mindreadr/src/test/io/lowkeylab/mindreadr:CalculateAllowedOriginsTest`
- `bazel build //mindreadr/src/main/io/lowkeylab/mindreadr/app:app_image`
- `aspect build //...`
- `aspect lint //...`

Known local broad-test failures:

- `aspect test //...` completed with 16 local failures.
- Failures appear unrelated to Java 25:
  - Rust/Go DB tests fail because `/var/run/docker.sock` is unavailable for testcontainers.
  - Two Angular Vitest targets fail creating `.vitest-coverage` directories under Bazel output paths.

## Notes

Implementation was done in dedicated worktree branch `pi/java-25-update` from the approved design `/tmp/pi-designs/2026-06-07-java-25-repo-update-design.md` and plan `/tmp/pi-plans/2026-06-07-java-25-repo-update-plan.md`.
