### PR TITLE
feat: Show server names on Nicknamer dashboard

### DIFF
--- a/angular/projects/nicknamer2-web/src/app/dashboard/dashboard.component.spec.ts
+++ b/angular/projects/nicknamer2-web/src/app/dashboard/dashboard.component.spec.ts
@@ -38,8 +38,20 @@ describe('DashboardComponent', () => {
         servers: {
           totalCount: 5,
           edges: [
-            { node: { id: 'relay-1', serverId: '111' } },
-            { node: { id: 'relay-2', serverId: '222' } },
+            {
+              node: {
+                id: 'relay-1',
+                serverId: '111',
+                displayName: 'Primary Server',
+              },
+            },
+            {
+              node: {
+                id: 'relay-2',
+                serverId: '222',
+                displayName: 'Backup Server',
+              },
+            },
           ],
         },
       },
@@ -57,7 +69,9 @@ describe('DashboardComponent', () => {
       '[data-testid="server-card"]',
     );
     expect(cards.length).toBe(2);
+    expect(cards[0].textContent).toContain('Primary Server');
     expect(cards[0].textContent).toContain('111');
+    expect(cards[1].textContent).toContain('Backup Server');
     expect(cards[1].textContent).toContain('222');
   });
 
@@ -119,7 +133,15 @@ describe('DashboardComponent', () => {
       data: {
         servers: {
           totalCount: 1,
-          edges: [{ node: { id: 'relay-1', serverId: '111' } }],
+          edges: [
+            {
+              node: {
+                id: 'relay-1',
+                serverId: '111',
+                displayName: 'Primary Server',
+              },
+            },
+          ],
         },
       },
     });

--- a/angular/projects/nicknamer2-web/src/app/dashboard/dashboard.component.ts
+++ b/angular/projects/nicknamer2-web/src/app/dashboard/dashboard.component.ts
@@ -58,7 +58,8 @@ type ServerEdge = GetDashboardQuery['servers']['edges'][number];
               class="card bg-base-200 hover:bg-base-300 transition-colors cursor-pointer"
             >
               <div class="card-body">
-                <h3 class="card-title">Server {{ edge.node.serverId }}</h3>
+                <h3 class="card-title">{{ edge.node.displayName }}</h3>
+                <p class="text-sm opacity-70">{{ edge.node.serverId }}</p>
               </div>
             </a>
           }

--- a/angular/projects/nicknamer2-web/src/app/graphql/get-dashboard.graphql
+++ b/angular/projects/nicknamer2-web/src/app/graphql/get-dashboard.graphql
@@ -5,6 +5,7 @@ query GetDashboard($first: Int!) {
       node {
         id
         serverId
+        displayName
       }
     }
   }

--- a/angular/projects/nicknamer2-web/src/generated/graphql.ts
+++ b/angular/projects/nicknamer2-web/src/generated/graphql.ts
@@ -254,7 +254,12 @@ export type GetDashboardQuery = {
     totalCount: number;
     edges: Array<{
       __typename?: 'ServerEdge';
-      node: { __typename?: 'Server'; id: string; serverId: string };
+      node: {
+        __typename?: 'Server';
+        id: string;
+        serverId: string;
+        displayName: string;
+      };
     }>;
   };
 };
@@ -328,6 +333,7 @@ export const GetDashboardDocument = gql`
         node {
           id
           serverId
+          displayName
         }
       }
     }


### PR DESCRIPTION
## Summary
- Fetch displayName in the Nicknamer2 dashboard query
- Render server display names on dashboard cards while keeping server IDs visible
- Update dashboard tests and generated GraphQL types

## Validation
- git diff --check
- nix develop --command bash -lc 'P="/home/tacascer/.pi/agent/bin:/nix/store/wci2b3l9gs8nq3alx6czffsq55bg44cv-fd-10.4.2/bin:/nix/store/gxcm97c2a4sdnnabigp8mns7y1g5llnd-ripgrep-15.1.0/bin::/home/tacascer/.local/bin:/run/wrappers/bin:/home/tacascer/.nix-profile/bin:/nix/profile/bin:/home/tacascer/.local/state/nix/profile/bin:/etc/profiles/per-user/tacascer/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin"; bazel test //angular/projects/nicknamer2-web:test --spawn_strategy=local --strategy=Jq=local --strategy=Genrule=local --remote_executor= --remote_cache= --action_env=PATH="" --host_action_env=PATH="" --test_env=PATH=""'
- agent-browser local dashboard smoke test with mocked GraphQL response

Note: plain `bazel run gazelle` in the Nix dev shell currently fails in this environment because Bazel actions cannot find `/run/current-system/sw/bin/bash`/basic shell tools in action PATH.