### PR TITLE
fix: unset ANDROID_HOME for Renovate Maven pin

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,7 @@
       ],
       "postUpgradeTasks": {
         "commands": [
-          "env REPIN=1 bazel run @maven//:pin --config=ci-remote"
+          "env -u ANDROID_HOME REPIN=1 bazel run @maven//:pin --config=ci-remote"
         ],
         "fileFilters": [
           "maven_install.json"


### PR DESCRIPTION
## Summary
- update Renovate's Maven artifact repin command to unset `ANDROID_HOME`
- avoid `rules_android` failing on containerbase's incomplete Android SDK during Maven-only repins

## Why
Renovate failed to refresh `maven_install.json` for #1288 after updating `org.jetbrains.exposed:exposed-dao` in `MODULE.bazel`.

The failed artifact command was:

```bash
env REPIN=1 bazel run @maven//:pin --config=ci-remote
```

In Renovate's environment, `ANDROID_HOME` pointed at `/home/ubuntu/.android-sdk`, but that SDK did not contain installed Android API platforms. During Bazel analysis, `rules_android` treated that set-but-invalid SDK path as a hard error and aborted before the Maven pin could complete.

The Maven pin does not need Android, so this PR changes the post-upgrade task to run with `ANDROID_HOME` unset:

```bash
env -u ANDROID_HOME REPIN=1 bazel run @maven//:pin --config=ci-remote
```

## Note
This requires the shared Renovate runner allowlist update in LowkeyLab/renovatebot#19.

## Test
- `python -m json.tool renovate.json`
