### PR TITLE
revert: restore Renovate Maven pin command

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,7 @@
       ],
       "postUpgradeTasks": {
         "commands": [
-          "env -u ANDROID_HOME REPIN=1 bazel run @maven//:pin --config=ci-remote"
+          "env REPIN=1 bazel run @maven//:pin --config=ci-remote"
         ],
         "fileFilters": [
           "maven_install.json"


### PR DESCRIPTION
## Summary
- revert #1289
- restore the Renovate Maven repin command to use the previous `env REPIN=1 bazel run @maven//:pin --config=ci-remote` form

## Why
Unsetting `ANDROID_HOME` did not fix the Renovate artifact update problem, so this reverts that workaround while we investigate a different fix.

## Test
- `python -m json.tool renovate.json`