### PR TITLE
fix: Remove email link from personal website navbar

### DIFF
--- a/personal_website/src/components/Navbar.astro
+++ b/personal_website/src/components/Navbar.astro
@@ -55,13 +55,6 @@ const isActive = (item: string) => activeItem === item;
               >Blog</a
             >
           </li>
-          <li>
-            <a
-              href="mailto:timdttran2000@gmail.com"
-              target="_blank"
-              rel="noreferrer">Email</a
-            >
-          </li>
         </ul>
       </div>
 
@@ -91,13 +84,6 @@ const isActive = (item: string) => activeItem === item;
           <li>
             <a class={isActive("blog") ? "menu-active" : ""} href="/blog"
               >Blog</a
-            >
-          </li>
-          <li>
-            <a
-              href="mailto:timdttran2000@gmail.com"
-              target="_blank"
-              rel="noreferrer">Email</a
             >
           </li>
         </ul>


### PR DESCRIPTION
## Summary
- remove the Email mailto link from the personal website mobile navbar
- remove the Email mailto link from the personal website desktop navbar

## Validation
- bazel run gazelle
- format
- aspect build //personal_website:build