### PR TITLE
ci: reduce Bazel CI logging

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -96,6 +96,9 @@ coverage:ci-remote --@rules_go//go/config:pure
 run:quiet --ui_event_filters=-info,-stdout,-stderr --noshow_progress
 
 # Bazel Preset Overrides
+# GitHub Actions does not interpret cursor controls, so curses produces excessive log lines.
+common:ci --curses=no
+
 # CI lint: enable remote execution and download toplevel outputs for lint report files
 common:ci-lint --config=ci-remote
 common:ci-lint --remote_download_toplevel

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -9,6 +9,10 @@ load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 bazelrc_preset(
     name = "preset",
     doc_link_template = "https://registry.build/flag/bazel?filter={flag}",
+    extra_presets = {
+        # Progress is rendered without cursor controls in CI, so no additional rate limit is needed.
+        "show_progress_rate_limit": {"if_bazel_version": False},
+    },
 )
 
 npm_link_all_packages(name = "node_modules")

--- a/tools/preset.bazelrc
+++ b/tools/preset.bazelrc
@@ -162,12 +162,6 @@ common --reuse_sandbox_directories
 common --nosandbox_default_allow_network
 # Docs: https://registry.build/flag/bazel?filter=sandbox_default_allow_network
 
-# Only show progress every 60 seconds on CI.
-# We want to find a compromise between printing often enough to show that the build isn't stuck,
-# but not so often that we produce a long log file that requires a lot of scrolling.
-common:ci --show_progress_rate_limit=60
-# Docs: https://registry.build/flag/bazel?filter=show_progress_rate_limit
-
 # The printed files are convenient strings for copy+pasting to the shell, to execute them.
 # This option requires an integer argument, which is the threshold number of targets above which result information is not printed.
 # Show the output files created by builds that requested more than one target.


### PR DESCRIPTION
## Summary

- disable Bazel curses in CI because GitHub Actions does not interpret cursor-control redraws
- omit the preset CI progress-rate limit now that progress uses non-cursor output
- retain Bazel errors, warnings, results, and ordinary progress output

## Validation

- `bazel run gazelle`
- `nix develop -c format`
- effective `bazel info --config=ci --announce_rc` configuration check
- `aspect test //tools:preset.update_test`
- `aspect build //...`
- `git diff --check`