### PR TITLE
chore: adopt Renovate best practices preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:best-practices", ":approveMajorUpdates", ":automergeAll"],
+  "nix": {
+    "enabled": true
+  },
   "packageRules": [
     {
       "matchManagers": ["bazel-module"],

--- a/renovate.json
+++ b/renovate.json
@@ -1,53 +1,26 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended",
-    ":approveMajorUpdates",
-    ":automergeAll"
-  ],
-  "nix": {
-    "enabled": true
-  },
-  "lockFileMaintenance": {
-    "enabled": true,
-    "schedule": [
-      "* 4 * * *"
-    ]
-  },
+  "extends": ["config:best-practices", ":approveMajorUpdates", ":automergeAll"],
   "packageRules": [
     {
-      "matchManagers": [
-        "bazel-module"
-      ],
-      "matchDatasources": [
-        "maven"
-      ],
+      "matchManagers": ["bazel-module"],
+      "matchDatasources": ["maven"],
       "postUpgradeTasks": {
-        "commands": [
-          "env REPIN=1 bazel run @maven//:pin --config=ci-remote"
-        ],
-        "fileFilters": [
-          "maven_install.json"
-        ],
+        "commands": ["env REPIN=1 bazel run @maven//:pin --config=ci-remote"],
+        "fileFilters": ["maven_install.json"],
         "executionMode": "update"
       }
     },
     {
-      "matchManagers": [
-        "cargo"
-      ],
+      "matchManagers": ["cargo"],
       "postUpgradeTasks": {
         "commands": [
           "bazel mod deps --lockfile_mode=update --config=ci-remote"
         ],
-        "fileFilters": [
-          "MODULE.bazel.lock"
-        ],
+        "fileFilters": ["MODULE.bazel.lock"],
         "executionMode": "update"
       }
     }
   ],
-  "postUpdateOptions": [
-    "gomodTidy"
-  ]
+  "postUpdateOptions": ["gomodTidy"]
 }


### PR DESCRIPTION
## Summary
- replace `config:recommended` with `config:best-practices`
- inherit the preset’s weekly lock-file maintenance schedule
- keep explicit Nix manager enablement because Renovate disables it by default
- preserve major-update approval, automerge, package rules, and `gomodTidy`

## Validation
- `format`
- `aspect lint`
- `aspect build //...`
- `renovate-config-validator renovate.json` (Renovate Docker image)
- local full Renovate dry run with `--platform=local`