### PR TITLE
fix: configure Maven Central for Clojure

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,6 @@
-{:deps
+{:mvn/repos
+ {"central" {:url "https://repo1.maven.org/maven2/"}}
+ :deps
  {org.clojure/clojure {:mvn/version "1.12.1"}}
  :paths ["clojure_sample/src" "clojure_sample/test"]
  :aliases


### PR DESCRIPTION
## Summary

- configure Maven Central explicitly in `deps.edn`
- allow `rules_clojure` to resolve Clojure versions that are not pre-seeded in its local Maven repository
- unblock #1109 without changing `maven_install.json`, which is managed by a separate Bazel module extension

## Validation

- `nix develop -c bazel run gazelle`
- `nix develop -c bazel run //:clojure_gen_build_files`
- `nix develop -c format`
- temporarily set Clojure to 1.12.5 and ran `nix develop -c bazel build //:clojure_gen_build_files`
- `nix develop -c aspect test //clojure_sample/test/lowkeylab/clojure_sample:core_test.test`
- `nix develop -c aspect build //...`
