### PR TITLE
refactor: Run Aspect tests with shared BuildBuddy remote execution

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -23,6 +23,7 @@ common:remote-linux --host_platform=//platforms:remote_linux_x86_64_gnu_llvm
 test:remote-linux --test_tag_filters=-no-remote
 
 # CI remote execution config (combines remote-linux with CI tuning)
+common:ci --config=ci-remote
 common:ci-remote --config=remote-linux
 common:ci-remote --remote_timeout=3600
 common:ci-remote --incompatible_strict_action_env
@@ -96,8 +97,7 @@ coverage:ci-remote --@rules_go//go/config:pure
 run:quiet --ui_event_filters=-info,-stdout,-stderr --noshow_progress
 
 # Bazel Preset Overrides
-# CI lint: enable remote execution and download toplevel outputs for lint report files
-common:ci-lint --config=ci-remote
+# CI lint: download toplevel outputs for lint report files
 common:ci-lint --remote_download_toplevel
 
 # Load any settings & overrides specific to the current user.

--- a/.github/actions/setup-bazel-ci/action.yml
+++ b/.github/actions/setup-bazel-ci/action.yml
@@ -20,6 +20,11 @@ runs:
           experimental-features = nix-command flakes
     - name: Configure Magic Nix Cache
       uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39
+    - name: Install Aspect from flake
+      shell: bash
+      run: |
+        nix build .#aspect
+        install -Dm755 ./result/bin/aspect /usr/local/bin/aspect
     - uses: bazel-contrib/setup-bazel@d68576867819dfdec2cf9586a68795f81461da3e
       with:
         # Avoid downloading Bazel every time.

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -38,8 +38,8 @@ jobs:
         run: |
           nix build nixpkgs#lcov
           install -m755 ./result/bin/lcov ./result/bin/genhtml ./result/bin/geninfo /usr/local/bin/
-      - name: Run Coverage (remote)
-        run: bazel run //tools/coverage -- //... --config=ci-remote
+      - name: Run Coverage
+        run: bazel run //tools/coverage -- //...
       - name: Upload to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,7 +26,7 @@ jobs:
           bazelisk-cache: true
           bazelrc: |
             common --config=ci
-            build --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}
+            common --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}
             test --test_env=XDG_CACHE_HOME
       - name: Log in to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           bazelisk-cache: true
           bazelrc: |
-            common --config=ci-remote
+            common --config=ci
             common --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}
       - name: Install Aspect from flake
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,10 +24,6 @@ jobs:
           buildbuddy-api-key: ${{ secrets.BUILDBUDDY_API_KEY }}
           docker-hub-username: ${{ vars.DOCKER_HUB_USERNAME }}
           docker-hub-token: ${{ secrets.DOCKER_HUB_TOKEN }}
-      - name: Install Aspect from flake
-        run: |
-          nix build .#aspect
-          install -Dm755 ./result/bin/aspect /usr/local/bin/aspect
       - name: Run Bazel Lints
         env:
           ASPECT_API_TOKEN: ${{ secrets.ASPECT_API_TOKEN }}
@@ -44,6 +40,8 @@ jobs:
           buildbuddy-api-key: ${{ secrets.BUILDBUDDY_API_KEY }}
           docker-hub-username: ${{ vars.DOCKER_HUB_USERNAME }}
           docker-hub-token: ${{ secrets.DOCKER_HUB_TOKEN }}
-      - name: Run Bazel tests (remote)
+      - name: Run Bazel tests
+        env:
+          ASPECT_API_TOKEN: ${{ secrets.ASPECT_API_TOKEN }}
         run: |
-          bazel test //... --config=ci-remote
+          aspect test //...

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,14 +52,12 @@ bazel run @pnpm -- --dir $PWD install
 
 ### Remote execution
 
-CI uses `--config=ci-remote` for remote build execution via BuildBuddy (with `--noremote_local_fallback`). To test locally:
+CI selects `--config=ci`, which expands to `--config=ci-remote` and enables BuildBuddy remote execution. Aspect commands inherit this Bazel configuration from the CI-generated bazelrc. To test remote execution locally:
 
 ```bash
 bazel build //... --config=remote-linux
 bazel test //... --config=remote-linux
 ```
-
-Note: Use `bazel` (not `aspect`) for remote execution — the Aspect CLI does not support `--config` flags.
 
 ### After editing source files, always:
 
@@ -142,7 +140,7 @@ Angular 21 projects live in `angular/projects/` (mindreadr, nicknamer, predix, t
 
 ### CI/CD
 
-- **run-tests.yml**: on push/PR to main — installs `aspect` from `.#aspect`, then runs `aspect lint //...` and `aspect test //...` with BuildBuddy remote cache
+- **run-tests.yml**: on push/PR to main — uses the shared Bazel CI setup (including `aspect` from `.#aspect`), then runs `aspect lint //...` and `aspect test //...` with BuildBuddy remote execution
 - **deploy.yml**: after tests pass on main — builds optimized and pushes all OCI images to GHCR
 
 ## Code Conventions


### PR DESCRIPTION
## Summary
- make `--config=ci` automatically enable the shared BuildBuddy remote execution configuration
- install the flake-pinned Aspect CLI in the shared Bazel CI setup action and run tests with `aspect test //...`
- remove redundant workflow-specific `ci-remote` plumbing from lint, coverage, and deployment configuration

## Validation
- `format`
- `git diff --check`
- isolated Bazel config expansion check for `ci -> ci-remote -> remote-linux -> remote`
- `aspect lint --bazel-flag=--config=ci //...`
- `aspect test --bazel-flag=--config=ci //...`
- `aspect build --bazel-flag=--config=ci //...`
