### PR TITLE
refactor: use native Aspect lint task

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -1,12 +1,5 @@
-load("@aspect//traits.axl", "BazelTrait")
-
-def _lint_bazel_flags(ctx):
-    if ctx.task.kind == "lint":
-        return ["--config=lint"]
-    return []
-
 def config(ctx):
-    ctx.traits[BazelTrait].task_flags.append(_lint_bazel_flags)
+    ctx.tasks["lint"].args.bazel_flags = ["--config=lint"]
     ctx.tasks["lint"].args.aspects = [
         "//tools/lint:linters.bzl%buf",
         "//tools/lint:linters.bzl%eslint",

--- a/MODULE.aspect
+++ b/MODULE.aspect
@@ -1,9 +1,0 @@
-# AXL dependencies; see https://github.com/aspect-extensions
-axl_archive_dep(
-    name = "aspect_rules_lint",
-    urls = ["https://github.com/aspect-build/rules_lint/releases/download/v2.7.1/rules_lint-v2.7.1.tar.gz"],
-    integrity = "sha256-R/EhvnPoYQswxUjsQXIdDoPZQH9JX2DY7uIJslqkVWc=",
-    strip_prefix = "rules_lint-2.7.1",
-    dev = True,
-    auto_use_tasks = False,
-)


### PR DESCRIPTION
## Summary
- configure the built-in Aspect lint task directly with the repository lint Bazel config
- preserve the existing repository-specific lint aspect list
- remove the obsolete `MODULE.aspect` AXL archive dependency

## Validation
- `bazel run gazelle`
- `format`
- `aspect lint --help`
- `aspect lint //...`
- `aspect build //...`
- `git diff --check`