### PR TITLE
feat: add Kafka input and constant nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5777,6 +5777,7 @@ dependencies = [
  "pinyinchch-model-hmm",
  "regex",
  "reqwest",
+ "rust_decimal",
  "sea-orm",
  "sea-orm-migration",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ pinyin = "0.11"
 pinyinchch = { version = "0.3.0", features = ["hmm"] }
 pinyinchch-model-hmm = "0.3.0"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
+rust_decimal = "1.39.0"
 sea-orm = { version = "1.1.16", features = [
   "sqlx-postgres",
   "runtime-tokio-rustls",

--- a/kafka_calculator/core/BUILD.bazel
+++ b/kafka_calculator/core/BUILD.bazel
@@ -8,9 +8,13 @@ rust_library(
     srcs = [
         "lib.rs",
         "node.rs",
+        "value.rs",
     ],
     crate_name = "kafka_calculator_core",
-    deps = ["@crates//:thiserror"],
+    deps = [
+        "@crates//:rust_decimal",
+        "@crates//:thiserror",
+    ],
 )
 
 rust_test(

--- a/kafka_calculator/core/lib.rs
+++ b/kafka_calculator/core/lib.rs
@@ -3,5 +3,11 @@
 #![forbid(unsafe_code)]
 
 mod node;
+mod value;
 
-pub use node::{Citation, CitationClaim, CitationId, IdentifierError, NodeId, NodeMetadata};
+pub use node::{
+    Citation, CitationClaim, CitationId, ConstantDefinition, ConstantOrigin, IdentifierError,
+    InputConstraint, InputDefinition, InputDefinitionError, NodeDefinition, NodeId, NodeKind,
+    NodeMetadata,
+};
+pub use value::{DataSize, DataUnit, ExactDecimal, Value, ValueError, ValueType};

--- a/kafka_calculator/core/node.rs
+++ b/kafka_calculator/core/node.rs
@@ -2,7 +2,7 @@ use std::{fmt, str::FromStr};
 
 use thiserror::Error;
 
-use crate::{Value, ValueType};
+use crate::value::{Value, ValueType};
 
 /// Error returned when a graph identifier does not use the canonical syntax.
 #[derive(Clone, Debug, Eq, Error, PartialEq)]

--- a/kafka_calculator/core/node.rs
+++ b/kafka_calculator/core/node.rs
@@ -2,6 +2,8 @@ use std::{fmt, str::FromStr};
 
 use thiserror::Error;
 
+use crate::{Value, ValueType};
+
 /// Error returned when a graph identifier does not use the canonical syntax.
 #[derive(Clone, Debug, Eq, Error, PartialEq)]
 pub enum IdentifierError {
@@ -189,6 +191,172 @@ impl NodeMetadata {
     }
 }
 
+/// Why a fixed value is part of the calculation graph.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ConstantOrigin {
+    /// A mathematical or measurement-unit definition.
+    UnitDefinition,
+    /// A default defined by the Kafka client.
+    ClientDefault,
+    /// A bound or requirement imposed by the Kafka client.
+    ClientConstraint,
+    /// A deliberate policy chosen by this calculator.
+    CalculatorPolicy,
+}
+
+/// The kind-specific definition of a fixed graph node.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ConstantDefinition {
+    value: Value,
+    origin: ConstantOrigin,
+    rationale: String,
+}
+
+impl ConstantDefinition {
+    pub fn new(value: Value, origin: ConstantOrigin, rationale: String) -> Self {
+        Self {
+            value,
+            origin,
+            rationale,
+        }
+    }
+
+    pub fn value(&self) -> Value {
+        self.value
+    }
+
+    pub fn origin(&self) -> ConstantOrigin {
+        self.origin
+    }
+
+    pub fn rationale(&self) -> &str {
+        &self.rationale
+    }
+}
+
+/// Kind-specific data attached to a graph node definition.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum NodeKind {
+    Input(InputDefinition),
+    Constant(ConstantDefinition),
+}
+
+/// A graph node's common metadata and kind-specific definition.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NodeDefinition {
+    metadata: NodeMetadata,
+    kind: NodeKind,
+}
+
+impl NodeDefinition {
+    pub fn new(metadata: NodeMetadata, kind: NodeKind) -> Self {
+        Self { metadata, kind }
+    }
+
+    pub fn metadata(&self) -> &NodeMetadata {
+        &self.metadata
+    }
+
+    pub fn kind(&self) -> &NodeKind {
+        &self.kind
+    }
+}
+
+/// A hard bound that an input value must satisfy during binding.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InputConstraint {
+    MinimumInclusive(Value),
+    MinimumExclusive(Value),
+    MaximumInclusive(Value),
+    MaximumExclusive(Value),
+}
+
+impl InputConstraint {
+    /// Returns the bound value used by this constraint.
+    pub fn value(self) -> Value {
+        match self {
+            Self::MinimumInclusive(value)
+            | Self::MinimumExclusive(value)
+            | Self::MaximumInclusive(value)
+            | Self::MaximumExclusive(value) => value,
+        }
+    }
+}
+
+/// Error returned when an input definition contains incompatible values.
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+pub enum InputDefinitionError {
+    /// The default value does not have the input's declared type.
+    #[error("input default has type {actual:?}, expected {expected:?}")]
+    DefaultTypeMismatch {
+        expected: ValueType,
+        actual: ValueType,
+    },
+    /// A hard constraint does not have the input's declared type.
+    #[error("input constraint {index} has type {actual:?}, expected {expected:?}")]
+    ConstraintTypeMismatch {
+        index: usize,
+        expected: ValueType,
+        actual: ValueType,
+    },
+}
+
+/// Type, optional default, and hard constraints declared by an input node.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InputDefinition {
+    value_type: ValueType,
+    default: Option<Value>,
+    hard_constraints: Vec<InputConstraint>,
+}
+
+impl InputDefinition {
+    /// Creates an input definition whose default and constraints match its declared type.
+    pub fn new(
+        value_type: ValueType,
+        default: Option<Value>,
+        hard_constraints: Vec<InputConstraint>,
+    ) -> Result<Self, InputDefinitionError> {
+        if let Some(default) = default {
+            let actual = default.value_type();
+            if actual != value_type {
+                return Err(InputDefinitionError::DefaultTypeMismatch {
+                    expected: value_type,
+                    actual,
+                });
+            }
+        }
+
+        for (index, constraint) in hard_constraints.iter().copied().enumerate() {
+            let actual = constraint.value().value_type();
+            if actual != value_type {
+                return Err(InputDefinitionError::ConstraintTypeMismatch {
+                    index,
+                    expected: value_type,
+                    actual,
+                });
+            }
+        }
+
+        Ok(Self {
+            value_type,
+            default,
+            hard_constraints,
+        })
+    }
+
+    pub fn value_type(&self) -> ValueType {
+        self.value_type
+    }
+
+    pub fn default(&self) -> Option<Value> {
+        self.default
+    }
+
+    pub fn hard_constraints(&self) -> &[InputConstraint] {
+        &self.hard_constraints
+    }
+}
+
 fn validate_identifier(value: &str) -> Result<(), IdentifierError> {
     if value.is_empty() {
         return Err(IdentifierError::Empty);
@@ -232,6 +400,7 @@ mod tests {
     use googletest::prelude::*;
 
     use super::*;
+    use crate::{DataSize, DataUnit, ExactDecimal};
 
     #[googletest::test]
     fn node_id_accepts_canonical_identifiers() {
@@ -354,6 +523,147 @@ mod tests {
         assert_that!(
             claim.claim(),
             eq("The producer queue is shared by all partitions.")
+        );
+    }
+
+    #[googletest::test]
+    fn constant_definition_exposes_its_fixed_value_origin_and_rationale() {
+        let value = Value::DataSize(DataSize::new(
+            ExactDecimal::from_str("1024").expect("decimal should be valid"),
+            DataUnit::Bytes,
+        ));
+        let rationale =
+            String::from("librdkafka interprets producer configuration KBytes as 1,024 bytes.");
+        let definition =
+            ConstantDefinition::new(value, ConstantOrigin::UnitDefinition, rationale.clone());
+
+        assert_that!(definition.value(), eq(value));
+        assert_that!(definition.origin(), eq(ConstantOrigin::UnitDefinition));
+        assert_that!(definition.rationale(), eq(rationale.as_str()));
+
+        let metadata = NodeMetadata::new(
+            NodeId::new("constant.producer.config_kbyte_bytes")
+                .expect("node identifier should be valid"),
+            String::from("Producer configuration KByte divisor"),
+            String::from("Number of bytes represented by one producer configuration KByte."),
+            vec![],
+        );
+        let node = NodeDefinition::new(metadata, NodeKind::Constant(definition.clone()));
+
+        assert_that!(
+            node.metadata().id().as_str(),
+            eq("constant.producer.config_kbyte_bytes")
+        );
+        assert_that!(node.kind(), eq(&NodeKind::Constant(definition)));
+    }
+
+    #[googletest::test]
+    fn constant_origins_cover_every_fixed_value_source() {
+        let origins = [
+            ConstantOrigin::UnitDefinition,
+            ConstantOrigin::ClientDefault,
+            ConstantOrigin::ClientConstraint,
+            ConstantOrigin::CalculatorPolicy,
+        ];
+
+        for origin in origins {
+            let definition =
+                ConstantDefinition::new(Value::MessageCount(1), origin, String::from("Reason"));
+
+            assert_that!(definition.origin(), eq(origin));
+        }
+    }
+
+    #[googletest::test]
+    fn input_definition_exposes_its_declaration() {
+        let default = Value::MessageCount(100_000);
+        let constraints = vec![
+            InputConstraint::MinimumExclusive(Value::MessageCount(0)),
+            InputConstraint::MaximumInclusive(Value::MessageCount(1_000_000)),
+        ];
+        let definition =
+            InputDefinition::new(ValueType::MessageCount, Some(default), constraints.clone())
+                .expect("matching default and constraints should be accepted");
+
+        assert_that!(definition.value_type(), eq(ValueType::MessageCount));
+        assert_that!(definition.default(), eq(Some(default)));
+        assert_that!(definition.hard_constraints(), eq(constraints.as_slice()));
+        assert_that!(constraints[0].value(), eq(Value::MessageCount(0)));
+
+        let metadata = NodeMetadata::new(
+            NodeId::new("input.producer.queue_message_count")
+                .expect("node identifier should be valid"),
+            String::from("Producer queue message count"),
+            String::from("Target number of messages retained by the producer queue."),
+            vec![],
+        );
+        let node = NodeDefinition::new(metadata, NodeKind::Input(definition.clone()));
+
+        assert_that!(
+            node.metadata().id().as_str(),
+            eq("input.producer.queue_message_count")
+        );
+        assert_that!(node.kind(), eq(&NodeKind::Input(definition)));
+    }
+
+    #[googletest::test]
+    fn input_definition_accepts_a_required_input_without_constraints() {
+        let definition = InputDefinition::new(ValueType::Ratio, None, vec![])
+            .expect("required unconstrained input should be accepted");
+
+        assert_that!(definition.default(), none());
+        assert_that!(definition.hard_constraints().is_empty(), eq(true));
+    }
+
+    #[googletest::test]
+    fn input_definition_rejects_a_default_with_the_wrong_type() {
+        let error = InputDefinition::new(
+            ValueType::MessageCount,
+            Some(Value::Scalar(
+                ExactDecimal::from_str("10").expect("decimal should be valid"),
+            )),
+            vec![],
+        )
+        .expect_err("mismatched default should be rejected");
+
+        assert_that!(
+            error,
+            eq(&InputDefinitionError::DefaultTypeMismatch {
+                expected: ValueType::MessageCount,
+                actual: ValueType::Scalar,
+            })
+        );
+        assert_that!(
+            error.to_string(),
+            eq("input default has type Scalar, expected MessageCount")
+        );
+    }
+
+    #[googletest::test]
+    fn input_definition_rejects_a_constraint_with_the_wrong_type() {
+        let error = InputDefinition::new(
+            ValueType::MessageCount,
+            None,
+            vec![
+                InputConstraint::MinimumInclusive(Value::MessageCount(1)),
+                InputConstraint::MaximumExclusive(Value::Ratio(
+                    ExactDecimal::from_str("2").expect("decimal should be valid"),
+                )),
+            ],
+        )
+        .expect_err("mismatched constraint should be rejected");
+
+        assert_that!(
+            error,
+            eq(&InputDefinitionError::ConstraintTypeMismatch {
+                index: 1,
+                expected: ValueType::MessageCount,
+                actual: ValueType::Ratio,
+            })
+        );
+        assert_that!(
+            error.to_string(),
+            eq("input constraint 1 has type Ratio, expected MessageCount")
         );
     }
 

--- a/kafka_calculator/core/value.rs
+++ b/kafka_calculator/core/value.rs
@@ -1,0 +1,190 @@
+use std::{fmt, str::FromStr};
+
+use rust_decimal::Decimal;
+use thiserror::Error;
+
+/// Error returned when constructing an exact calculator value.
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+pub enum ValueError {
+    /// The supplied text is not an ordinary exact decimal.
+    #[error("`{value}` is not a valid exact decimal")]
+    InvalidDecimal { value: String },
+    /// Calculator values cannot be negative.
+    #[error("decimal value must not be negative, found `{value}`")]
+    NegativeDecimal { value: Decimal },
+}
+
+/// An exact, non-negative decimal value used by calculator quantities.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ExactDecimal(Decimal);
+
+impl ExactDecimal {
+    /// Creates an exact decimal after enforcing the calculator's non-negative domain.
+    pub fn new(value: Decimal) -> Result<Self, ValueError> {
+        if value.is_sign_negative() {
+            return Err(ValueError::NegativeDecimal { value });
+        }
+
+        Ok(Self(value))
+    }
+
+    /// Returns the underlying exact decimal.
+    pub fn value(self) -> Decimal {
+        self.0
+    }
+}
+
+impl fmt::Display for ExactDecimal {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+impl FromStr for ExactDecimal {
+    type Err = ValueError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let decimal = Decimal::from_str_exact(value).map_err(|_| ValueError::InvalidDecimal {
+            value: value.to_owned(),
+        })?;
+        Self::new(decimal)
+    }
+}
+
+/// Unit attached to a user-supplied or evaluated data-size quantity.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DataUnit {
+    Bytes,
+    Kilobytes,
+    Kibibytes,
+    Megabytes,
+    Mebibytes,
+}
+
+/// An exact data-size quantity that retains its declared SI or IEC unit.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DataSize {
+    amount: ExactDecimal,
+    unit: DataUnit,
+}
+
+impl DataSize {
+    pub fn new(amount: ExactDecimal, unit: DataUnit) -> Self {
+        Self { amount, unit }
+    }
+
+    pub fn amount(self) -> ExactDecimal {
+        self.amount
+    }
+
+    pub fn unit(self) -> DataUnit {
+        self.unit
+    }
+}
+
+/// Static category expected or produced by a graph node.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ValueType {
+    Scalar,
+    Ratio,
+    MessageCount,
+    DataSize,
+}
+
+/// A typed value accepted by an input node.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Value {
+    Scalar(ExactDecimal),
+    Ratio(ExactDecimal),
+    MessageCount(u128),
+    DataSize(DataSize),
+}
+
+impl Value {
+    /// Returns the static category of this value.
+    pub fn value_type(self) -> ValueType {
+        match self {
+            Self::Scalar(_) => ValueType::Scalar,
+            Self::Ratio(_) => ValueType::Ratio,
+            Self::MessageCount(_) => ValueType::MessageCount,
+            Self::DataSize(_) => ValueType::DataSize,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use googletest::prelude::*;
+    use rust_decimal::Decimal;
+
+    use super::*;
+
+    #[googletest::test]
+    fn exact_decimal_parses_ordinary_non_negative_values() {
+        let value = ExactDecimal::from_str("1024.500")
+            .expect("ordinary non-negative decimal should be accepted");
+
+        assert_that!(value.to_string(), eq("1024.500"));
+        assert_that!(value.value(), eq(Decimal::new(1_024_500, 3)));
+    }
+
+    #[googletest::test]
+    fn exact_decimal_rejects_unsupported_syntax() {
+        assert_that!(
+            ExactDecimal::from_str("1e3"),
+            err(eq(&ValueError::InvalidDecimal {
+                value: String::from("1e3")
+            }))
+        );
+        assert_that!(
+            ExactDecimal::from_str("NaN"),
+            err(eq(&ValueError::InvalidDecimal {
+                value: String::from("NaN")
+            }))
+        );
+    }
+
+    #[googletest::test]
+    fn exact_decimal_rejects_negative_values() {
+        let error = ExactDecimal::from_str("-0.5")
+            .expect_err("negative calculator value should be rejected");
+
+        assert_that!(
+            error,
+            eq(&ValueError::NegativeDecimal {
+                value: Decimal::new(-5, 1)
+            })
+        );
+        assert_that!(
+            error.to_string(),
+            eq("decimal value must not be negative, found `-0.5`")
+        );
+    }
+
+    #[googletest::test]
+    fn data_size_retains_its_exact_amount_and_unit() {
+        let amount = ExactDecimal::from_str("1.25").expect("decimal should be valid");
+        let size = DataSize::new(amount, DataUnit::Mebibytes);
+
+        assert_that!(size.amount(), eq(amount));
+        assert_that!(size.unit(), eq(DataUnit::Mebibytes));
+    }
+
+    #[googletest::test]
+    fn values_report_their_static_types() {
+        let decimal = ExactDecimal::from_str("1.5").expect("decimal should be valid");
+        let cases = [
+            (Value::Scalar(decimal), ValueType::Scalar),
+            (Value::Ratio(decimal), ValueType::Ratio),
+            (Value::MessageCount(10), ValueType::MessageCount),
+            (
+                Value::DataSize(DataSize::new(decimal, DataUnit::Kilobytes)),
+                ValueType::DataSize,
+            ),
+        ];
+
+        for (value, expected_type) in cases {
+            assert_that!(value.value_type(), eq(expected_type));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add the shared `NodeDefinition`/`NodeKind` wrapper with input and constant variants
- model constant origins, values, and rationale
- model typed input defaults and inclusive/exclusive hard constraints with construction-time type checks
- add exact non-negative decimal and SI/IEC data-size value types backed by `rust_decimal`

## Validation
- `bazel run gazelle`
- `aspect format --scope=all`
- `aspect test //kafka_calculator/core:core_test`
- `aspect lint //kafka_calculator/core:core //kafka_calculator/core:core_test`
- `bazel coverage //kafka_calculator/core:core_test` (100% lines/functions)
- `aspect build //...`
- `git diff --check`
