### PR TITLE
feat(kafka-calculator): add typed expression model

### DIFF
--- a/kafka_calculator/DESIGN.md
+++ b/kafka_calculator/DESIGN.md
@@ -169,11 +169,11 @@ A rationale explains why the graph contains the constant. Citations support clie
 
 ### Derived nodes
 
-A derived definition contains an expression and no precomputed value. The evaluator obtains its type and value from referenced nodes.
+A derived definition contains an `AnyExpression` and no precomputed value. The evaluator obtains its type and value from referenced nodes.
 
 ### Setting nodes
 
-A setting definition contains a client configuration key, producer/consumer/common scope, setting unit, and expression. Settings remain graph nodes so they can have incoming causes, citations, traces, constraints, and copied configuration representations.
+A setting definition contains a client configuration key, producer/consumer/common scope, setting unit, and `AnyExpression`. Settings remain graph nodes so they can have incoming causes, citations, traces, constraints, and copied configuration representations.
 
 ### Finding nodes
 
@@ -192,7 +192,7 @@ pub struct Operand {
 }
 ```
 
-The initial expression set is:
+The completed initial expression set is:
 
 - `Reference`
 - `Add`
@@ -202,6 +202,79 @@ The initial expression set is:
 - `Minimum`
 - `Maximum`
 - `ConvertDataSize`
+
+The first expression-model increment implements every operation above except `ConvertDataSize`. Unit conversion remains part of the completed architecture but is deliberately deferred to a later increment.
+
+### Typed expression construction
+
+An operation is represented by a marker type, and `Expression<K>` is the typed expression for that operation:
+
+```rust
+use std::marker::PhantomData;
+
+pub struct Reference;
+pub struct Add;
+pub struct Multiply;
+pub struct Ceiling;
+pub struct CeilingDivide;
+pub struct Minimum;
+pub struct Maximum;
+
+pub struct Expression<K> {
+    operands: Vec<Operand>,
+    kind: PhantomData<K>,
+}
+```
+
+The marker determines which constructors and accessors are available. There is no generic constructor that accepts an arbitrary operand vector. Fixed and minimum arities are instead encoded by operation-specific signatures:
+
+```rust
+impl Expression<Reference> {
+    pub fn new(source: Operand) -> Self;
+    pub fn source(&self) -> &Operand;
+}
+
+impl Expression<Add> {
+    pub fn new(left: Operand, right: Operand) -> Self;
+    pub fn and(self, term: Operand) -> Self;
+    pub fn terms(&self) -> &[Operand];
+}
+
+impl Expression<CeilingDivide> {
+    pub fn new(dividend: Operand, divisor: Operand) -> Self;
+    pub fn dividend(&self) -> &Operand;
+    pub fn divisor(&self) -> &Operand;
+}
+```
+
+`Multiply`, `Minimum`, and `Maximum` follow the same at-least-two pattern as `Add`, with operation-specific factor or candidate terminology. `Ceiling` follows the unary `Reference` shape but exposes the operand as the value being rounded. Private storage and typed constructors make invalid arity unrepresentable. Repeated node references remain valid, and variable-arity expressions preserve insertion order for deterministic edge generation, validation, and traces.
+
+The expression-only increment does not need a heterogeneous wrapper. When derived and setting nodes are implemented, the graph introduces an erased enum named `AnyExpression`:
+
+```rust
+pub enum AnyExpression {
+    Reference(Expression<Reference>),
+    Add(Expression<Add>),
+    Multiply(Expression<Multiply>),
+    Ceiling(Expression<Ceiling>),
+    CeilingDivide(Expression<CeilingDivide>),
+    Minimum(Expression<Minimum>),
+    Maximum(Expression<Maximum>),
+    ConvertDataSize(Expression<ConvertDataSize>),
+}
+```
+
+Conversions from each valid `Expression<K>` into `AnyExpression` keep graph assembly ergonomic without exposing an API that can bypass the typed constructors. The enum is preferred over trait objects because the closed operation set benefits from exhaustive matching and straightforward `Clone`, `Debug`, equality, validation, and later serialization support.
+
+Each typed operation also owns an operation-local static type contract. It accepts operand `ValueType`s that a future graph validator has already resolved; it does not perform graph lookup. The initial contracts are:
+
+- `Reference` preserves its source type.
+- `Add`, `Minimum`, and `Maximum` require homogeneous operand types and preserve that type.
+- `Multiply` supports homogeneous scalar or ratio multiplication and one data-size operand combined with scalar, ratio, or message-count factors. Dimensionally unsupported combinations such as data size multiplied by data size are rejected.
+- `Ceiling` preserves the accepted decimal quantity category.
+- `CeilingDivide` requires compatible whole-value categories and produces a scalar quotient.
+
+`ValueType` currently describes broad quantity categories rather than decimal whole-ness or a data size's concrete unit. Static contracts therefore reject category-level incompatibilities; the later evaluator remains responsible for checking whole values, matching units, division by zero, overflow, and decimal precision.
 
 Expressions contain no profile-specific numeric literals. Profile defaults, limits, policies, and divisors are constant nodes.
 
@@ -429,7 +502,7 @@ Tests use explicit assertions and focused helpers. Snapshot testing and `insta` 
 Test layers cover:
 
 - Exact decimal parsing, units, explicit rounding, and checked arithmetic
-- Expression constructor invariants and deterministic operand iteration
+- Typed expression APIs, constructor-enforced arity, deterministic operand iteration, and operation-local static type contracts
 - Graph validation errors, cycle paths, reachability, and deterministic topological order
 - Input defaults, origins, type checks, and constraints
 - Every generic operation's result and operation-specific trace

--- a/kafka_calculator/core/BUILD.bazel
+++ b/kafka_calculator/core/BUILD.bazel
@@ -6,6 +6,7 @@ package(default_visibility = ["//visibility:public"])
 rust_library(
     name = "core",
     srcs = [
+        "expression.rs",
         "lib.rs",
         "node.rs",
         "value.rs",

--- a/kafka_calculator/core/expression.rs
+++ b/kafka_calculator/core/expression.rs
@@ -37,7 +37,7 @@ pub enum ExpressionError {
         expected: usize,
         actual: usize,
     },
-    /// An operation requiring homogeneous operands encountered a different category.
+    /// An operand type does not satisfy the operation's static contract.
     #[error(
         "{operation} operand {operand} has type {actual:?}, but operand 0 has type {expected:?}"
     )]

--- a/kafka_calculator/core/expression.rs
+++ b/kafka_calculator/core/expression.rs
@@ -1,0 +1,539 @@
+use std::marker::PhantomData;
+
+use thiserror::Error;
+
+use crate::{NodeId, ValueType};
+
+/// A node used by an expression and the role it plays in the operation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Operand {
+    node_id: NodeId,
+    role: String,
+}
+
+impl Operand {
+    pub fn new(node_id: NodeId, role: String) -> Self {
+        Self { node_id, role }
+    }
+
+    pub fn node_id(&self) -> &NodeId {
+        &self.node_id
+    }
+
+    pub fn role(&self) -> &str {
+        &self.role
+    }
+}
+
+/// Error returned when resolved operand types violate an operation's static contract.
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+pub enum ExpressionError {
+    /// The graph validator supplied a different number of types than the expression has operands.
+    #[error(
+        "{operation} received {actual} resolved operand types, but the expression has {expected} operands"
+    )]
+    ResolvedTypeCountMismatch {
+        operation: &'static str,
+        expected: usize,
+        actual: usize,
+    },
+    /// An operation requiring homogeneous operands encountered a different category.
+    #[error(
+        "{operation} operand {operand} has type {actual:?}, but operand 0 has type {expected:?}"
+    )]
+    IncompatibleOperandType {
+        operation: &'static str,
+        operand: usize,
+        expected: ValueType,
+        actual: ValueType,
+    },
+    /// The complete operand-type combination is not dimensionally supported.
+    #[error("{operation} does not support operand types {operand_types:?}")]
+    UnsupportedOperandTypes {
+        operation: &'static str,
+        operand_types: Vec<ValueType>,
+    },
+}
+
+/// Marker for a node-reference expression.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Reference;
+
+/// Marker for an addition expression.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Add;
+
+/// Marker for a multiplication expression.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Multiply;
+
+/// Marker for an upward-rounding expression.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Ceiling;
+
+/// Marker for an upward-rounding whole-value division expression.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CeilingDivide;
+
+/// Marker for a minimum-selection expression.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Minimum;
+
+/// Marker for a maximum-selection expression.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Maximum;
+
+/// An expression whose operation and valid API are selected by marker `K`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Expression<K> {
+    operands: Vec<Operand>,
+    kind: PhantomData<K>,
+}
+
+impl Expression<Reference> {
+    pub fn new(source: Operand) -> Self {
+        Self::from_operands(vec![source])
+    }
+
+    pub fn source(&self) -> &Operand {
+        &self.operands[0]
+    }
+
+    /// Returns the source category unchanged.
+    pub fn result_type(&self, source_type: ValueType) -> ValueType {
+        source_type
+    }
+}
+
+impl Expression<Add> {
+    pub fn new(left: Operand, right: Operand) -> Self {
+        Self::from_operands(vec![left, right])
+    }
+
+    pub fn and(mut self, term: Operand) -> Self {
+        self.operands.push(term);
+        self
+    }
+
+    pub fn terms(&self) -> &[Operand] {
+        &self.operands
+    }
+
+    /// Requires homogeneous term categories and preserves their category.
+    pub fn result_type(&self, term_types: &[ValueType]) -> Result<ValueType, ExpressionError> {
+        homogeneous_result_type("add", self.operands.len(), term_types)
+    }
+}
+
+impl Expression<Multiply> {
+    pub fn new(left: Operand, right: Operand) -> Self {
+        Self::from_operands(vec![left, right])
+    }
+
+    pub fn and(mut self, factor: Operand) -> Self {
+        self.operands.push(factor);
+        self
+    }
+
+    pub fn factors(&self) -> &[Operand] {
+        &self.operands
+    }
+
+    /// Determines the product category for the supported dimensional combinations.
+    pub fn result_type(&self, factor_types: &[ValueType]) -> Result<ValueType, ExpressionError> {
+        ensure_resolved_type_count("multiply", self.operands.len(), factor_types.len())?;
+
+        if factor_types
+            .iter()
+            .all(|value_type| *value_type == ValueType::Scalar)
+        {
+            return Ok(ValueType::Scalar);
+        }
+        if factor_types
+            .iter()
+            .all(|value_type| *value_type == ValueType::Ratio)
+        {
+            return Ok(ValueType::Ratio);
+        }
+
+        let data_size_count = factor_types
+            .iter()
+            .filter(|value_type| **value_type == ValueType::DataSize)
+            .count();
+        if data_size_count == 1 {
+            return Ok(ValueType::DataSize);
+        }
+
+        Err(ExpressionError::UnsupportedOperandTypes {
+            operation: "multiply",
+            operand_types: factor_types.to_vec(),
+        })
+    }
+}
+
+impl Expression<Ceiling> {
+    pub fn new(value: Operand) -> Self {
+        Self::from_operands(vec![value])
+    }
+
+    pub fn value(&self) -> &Operand {
+        &self.operands[0]
+    }
+
+    /// Preserves a decimal quantity's broad category while making it whole at evaluation time.
+    pub fn result_type(&self, value_type: ValueType) -> Result<ValueType, ExpressionError> {
+        match value_type {
+            ValueType::Scalar | ValueType::Ratio | ValueType::DataSize => Ok(value_type),
+            ValueType::MessageCount => Err(ExpressionError::UnsupportedOperandTypes {
+                operation: "ceiling",
+                operand_types: vec![value_type],
+            }),
+        }
+    }
+}
+
+impl Expression<CeilingDivide> {
+    pub fn new(dividend: Operand, divisor: Operand) -> Self {
+        Self::from_operands(vec![dividend, divisor])
+    }
+
+    pub fn dividend(&self) -> &Operand {
+        &self.operands[0]
+    }
+
+    pub fn divisor(&self) -> &Operand {
+        &self.operands[1]
+    }
+
+    /// Requires compatible quantity categories and produces a scalar quotient.
+    pub fn result_type(
+        &self,
+        dividend_type: ValueType,
+        divisor_type: ValueType,
+    ) -> Result<ValueType, ExpressionError> {
+        if dividend_type == divisor_type {
+            Ok(ValueType::Scalar)
+        } else {
+            Err(ExpressionError::IncompatibleOperandType {
+                operation: "ceiling divide",
+                operand: 1,
+                expected: dividend_type,
+                actual: divisor_type,
+            })
+        }
+    }
+}
+
+impl Expression<Minimum> {
+    pub fn new(left: Operand, right: Operand) -> Self {
+        Self::from_operands(vec![left, right])
+    }
+
+    pub fn and(mut self, candidate: Operand) -> Self {
+        self.operands.push(candidate);
+        self
+    }
+
+    pub fn candidates(&self) -> &[Operand] {
+        &self.operands
+    }
+
+    /// Requires homogeneous candidate categories and preserves their category.
+    pub fn result_type(&self, candidate_types: &[ValueType]) -> Result<ValueType, ExpressionError> {
+        homogeneous_result_type("minimum", self.operands.len(), candidate_types)
+    }
+}
+
+impl Expression<Maximum> {
+    pub fn new(left: Operand, right: Operand) -> Self {
+        Self::from_operands(vec![left, right])
+    }
+
+    pub fn and(mut self, candidate: Operand) -> Self {
+        self.operands.push(candidate);
+        self
+    }
+
+    pub fn candidates(&self) -> &[Operand] {
+        &self.operands
+    }
+
+    /// Requires homogeneous candidate categories and preserves their category.
+    pub fn result_type(&self, candidate_types: &[ValueType]) -> Result<ValueType, ExpressionError> {
+        homogeneous_result_type("maximum", self.operands.len(), candidate_types)
+    }
+}
+
+impl<K> Expression<K> {
+    fn from_operands(operands: Vec<Operand>) -> Self {
+        Self {
+            operands,
+            kind: PhantomData,
+        }
+    }
+}
+
+fn homogeneous_result_type(
+    operation: &'static str,
+    operand_count: usize,
+    operand_types: &[ValueType],
+) -> Result<ValueType, ExpressionError> {
+    ensure_resolved_type_count(operation, operand_count, operand_types.len())?;
+
+    let expected = operand_types[0];
+    for (operand, actual) in operand_types.iter().copied().enumerate().skip(1) {
+        if actual != expected {
+            return Err(ExpressionError::IncompatibleOperandType {
+                operation,
+                operand,
+                expected,
+                actual,
+            });
+        }
+    }
+
+    Ok(expected)
+}
+
+fn ensure_resolved_type_count(
+    operation: &'static str,
+    expected: usize,
+    actual: usize,
+) -> Result<(), ExpressionError> {
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(ExpressionError::ResolvedTypeCountMismatch {
+            operation,
+            expected,
+            actual,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use googletest::prelude::*;
+
+    use super::*;
+
+    fn operand(id: &str, role: &str) -> Operand {
+        Operand::new(
+            NodeId::new(id).expect("test node identifier should be valid"),
+            role.to_owned(),
+        )
+    }
+
+    #[googletest::test]
+    fn operand_and_fixed_arity_expressions_expose_operation_specific_accessors() {
+        let source = operand("input.source", "source value");
+        let reference = Expression::<Reference>::new(source.clone());
+        let ceiling = Expression::<Ceiling>::new(source.clone());
+        let divisor = operand("constant.divisor", "configuration unit divisor");
+        let divide = Expression::<CeilingDivide>::new(source.clone(), divisor.clone());
+
+        assert_that!(source.node_id().as_str(), eq("input.source"));
+        assert_that!(source.role(), eq("source value"));
+        assert_that!(reference.source(), eq(&source));
+        assert_that!(ceiling.value(), eq(&source));
+        assert_that!(divide.dividend(), eq(&source));
+        assert_that!(divide.divisor(), eq(&divisor));
+    }
+
+    #[googletest::test]
+    fn variable_arity_expressions_preserve_operand_insertion_order() {
+        let first = operand("input.first", "first");
+        let second = operand("input.second", "second");
+        let third = operand("input.third", "third");
+
+        let addition = Expression::<Add>::new(first.clone(), second.clone()).and(third.clone());
+        let multiplication =
+            Expression::<Multiply>::new(first.clone(), second.clone()).and(third.clone());
+        let minimum = Expression::<Minimum>::new(first.clone(), second.clone()).and(third.clone());
+        let maximum = Expression::<Maximum>::new(first.clone(), second.clone()).and(third.clone());
+        let expected = [first, second, third];
+
+        assert_that!(addition.terms(), eq(expected.as_slice()));
+        assert_that!(multiplication.factors(), eq(expected.as_slice()));
+        assert_that!(minimum.candidates(), eq(expected.as_slice()));
+        assert_that!(maximum.candidates(), eq(expected.as_slice()));
+    }
+
+    #[googletest::test]
+    fn reference_preserves_every_source_type() {
+        let reference = Expression::<Reference>::new(operand("input.source", "source"));
+
+        for value_type in [
+            ValueType::Scalar,
+            ValueType::Ratio,
+            ValueType::MessageCount,
+            ValueType::DataSize,
+        ] {
+            assert_that!(reference.result_type(value_type), eq(value_type));
+        }
+    }
+
+    #[googletest::test]
+    fn homogeneous_operations_preserve_matching_types_and_reject_mismatches() {
+        let first = operand("input.first", "first");
+        let second = operand("input.second", "second");
+        let third = operand("input.third", "third");
+        let addition = Expression::<Add>::new(first.clone(), second.clone()).and(third.clone());
+        let minimum = Expression::<Minimum>::new(first.clone(), second.clone()).and(third.clone());
+        let maximum = Expression::<Maximum>::new(first, second).and(third);
+        let matching = [
+            ValueType::MessageCount,
+            ValueType::MessageCount,
+            ValueType::MessageCount,
+        ];
+        let mismatched = [
+            ValueType::MessageCount,
+            ValueType::MessageCount,
+            ValueType::DataSize,
+        ];
+
+        assert_that!(
+            addition.result_type(&matching),
+            ok(eq(&ValueType::MessageCount))
+        );
+        assert_that!(
+            minimum.result_type(&matching),
+            ok(eq(&ValueType::MessageCount))
+        );
+        assert_that!(
+            maximum.result_type(&matching),
+            ok(eq(&ValueType::MessageCount))
+        );
+        assert_that!(
+            addition.result_type(&mismatched),
+            err(eq(&ExpressionError::IncompatibleOperandType {
+                operation: "add",
+                operand: 2,
+                expected: ValueType::MessageCount,
+                actual: ValueType::DataSize,
+            }))
+        );
+        assert_that!(
+            minimum.result_type(&mismatched),
+            err(eq(&ExpressionError::IncompatibleOperandType {
+                operation: "minimum",
+                operand: 2,
+                expected: ValueType::MessageCount,
+                actual: ValueType::DataSize,
+            }))
+        );
+        assert_that!(
+            maximum.result_type(&mismatched),
+            err(eq(&ExpressionError::IncompatibleOperandType {
+                operation: "maximum",
+                operand: 2,
+                expected: ValueType::MessageCount,
+                actual: ValueType::DataSize,
+            }))
+        );
+    }
+
+    #[googletest::test]
+    fn variable_arity_contracts_reject_a_resolved_type_count_mismatch() {
+        let addition = Expression::<Add>::new(
+            operand("input.left", "left term"),
+            operand("input.right", "right term"),
+        )
+        .and(operand("input.extra", "additional term"));
+
+        assert_that!(
+            addition.result_type(&[ValueType::Scalar, ValueType::Scalar]),
+            err(eq(&ExpressionError::ResolvedTypeCountMismatch {
+                operation: "add",
+                expected: 3,
+                actual: 2,
+            }))
+        );
+    }
+
+    #[googletest::test]
+    fn multiply_accepts_supported_dimensional_combinations() {
+        let multiplication = Expression::<Multiply>::new(
+            operand("input.first", "first factor"),
+            operand("input.second", "second factor"),
+        )
+        .and(operand("input.third", "third factor"));
+
+        assert_that!(
+            multiplication.result_type(&[ValueType::Scalar, ValueType::Scalar, ValueType::Scalar,]),
+            ok(eq(&ValueType::Scalar))
+        );
+        assert_that!(
+            multiplication.result_type(&[ValueType::Ratio, ValueType::Ratio, ValueType::Ratio,]),
+            ok(eq(&ValueType::Ratio))
+        );
+        assert_that!(
+            multiplication.result_type(&[
+                ValueType::Ratio,
+                ValueType::DataSize,
+                ValueType::MessageCount,
+            ]),
+            ok(eq(&ValueType::DataSize))
+        );
+    }
+
+    #[googletest::test]
+    fn multiply_rejects_dimensionally_unsupported_combinations() {
+        let multiplication = Expression::<Multiply>::new(
+            operand("input.first", "first factor"),
+            operand("input.second", "second factor"),
+        );
+
+        for unsupported in [
+            [ValueType::DataSize, ValueType::DataSize],
+            [ValueType::Scalar, ValueType::Ratio],
+            [ValueType::MessageCount, ValueType::MessageCount],
+        ] {
+            assert_that!(
+                multiplication.result_type(&unsupported),
+                err(eq(&ExpressionError::UnsupportedOperandTypes {
+                    operation: "multiply",
+                    operand_types: unsupported.to_vec(),
+                }))
+            );
+        }
+    }
+
+    #[googletest::test]
+    fn ceiling_accepts_decimal_categories_and_rejects_message_counts() {
+        let ceiling = Expression::<Ceiling>::new(operand("input.value", "value to round"));
+
+        for value_type in [ValueType::Scalar, ValueType::Ratio, ValueType::DataSize] {
+            assert_that!(ceiling.result_type(value_type), ok(eq(&value_type)));
+        }
+        assert_that!(
+            ceiling.result_type(ValueType::MessageCount),
+            err(eq(&ExpressionError::UnsupportedOperandTypes {
+                operation: "ceiling",
+                operand_types: vec![ValueType::MessageCount],
+            }))
+        );
+    }
+
+    #[googletest::test]
+    fn ceiling_divide_requires_compatible_types_and_returns_a_scalar() {
+        let division = Expression::<CeilingDivide>::new(
+            operand("derived.queue_bytes", "queue bytes"),
+            operand("constant.config_unit_bytes", "configuration unit bytes"),
+        );
+
+        assert_that!(
+            division.result_type(ValueType::DataSize, ValueType::DataSize),
+            ok(eq(&ValueType::Scalar))
+        );
+        assert_that!(
+            division.result_type(ValueType::DataSize, ValueType::Scalar),
+            err(eq(&ExpressionError::IncompatibleOperandType {
+                operation: "ceiling divide",
+                operand: 1,
+                expected: ValueType::DataSize,
+                actual: ValueType::Scalar,
+            }))
+        );
+    }
+}

--- a/kafka_calculator/core/lib.rs
+++ b/kafka_calculator/core/lib.rs
@@ -2,9 +2,14 @@
 
 #![forbid(unsafe_code)]
 
+mod expression;
 mod node;
 mod value;
 
+pub use expression::{
+    Add, Ceiling, CeilingDivide, Expression, ExpressionError, Maximum, Minimum, Multiply, Operand,
+    Reference,
+};
 pub use node::{
     Citation, CitationClaim, CitationId, ConstantDefinition, ConstantOrigin, IdentifierError,
     InputConstraint, InputDefinition, InputDefinitionError, NodeDefinition, NodeId, NodeKind,


### PR DESCRIPTION
## Summary

- add marker-typed `Expression<K>` APIs for references, arithmetic, rounding, and bounds operations
- enforce operation arity through constructors and validate resolved operand types with explicit errors
- cover constructor/accessor behavior, deterministic operand ordering, and static type contracts
- document deferred `AnyExpression` graph storage and `ConvertDataSize` support

## Testing

- `bazel run gazelle`
- `aspect format --scope=all`
- `aspect test //kafka_calculator/...`
- `aspect lint //kafka_calculator/core:core`
- `bazel run //tools/coverage:coverage -- //kafka_calculator/core:core_test` (100% line/function coverage)
- `aspect build //...`
- `git diff --check origin/main...HEAD`
