### PR TITLE
docs: use absolute Gazelle target in instructions

### DIFF
--- a/.claude/skills/bazel-workflow/SKILL.md
+++ b/.claude/skills/bazel-workflow/SKILL.md
@@ -7,7 +7,7 @@ description: Run the full Bazel regeneration pipeline (gazelle, format, build) a
 
 Run the following pipeline in order, stopping on first failure:
 
-1. `bazel run gazelle` — regenerate BUILD files
+1. `bazel run //:gazelle` — regenerate BUILD files
 2. `format` — format all code
 3. `aspect build //...` — verify build
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ aspect build //...
 aspect test //...
 
 # Update BUILD files (MUST run immediately after ANY source file edit)
-bazel run gazelle
+bazel run //:gazelle
 
 # Format changed files (Rust, Kotlin, Go, JS/TS, BUILD files)
 aspect format
@@ -73,11 +73,11 @@ bazel clean && aspect build //...
 
 ### General Rules
 
-- **Gazelle:** MUST run `bazel run gazelle` immediately after editing ANY source file (.rs, .kt, .go, .ts, .js, .proto, etc.) and BEFORE formatting
+- **Gazelle:** MUST run `bazel run //:gazelle` immediately after editing ANY source file (.rs, .kt, .go, .ts, .js, .proto, etc.) and BEFORE formatting
 - **Formatting:** ALWAYS run `aspect format --scope=all` before committing or completing a task
 - **Minimal changes:** Only modify what's strictly necessary
 - **Dependencies:** Prefer existing libraries in `MODULE.bazel`
-- **BUILD files:** Never manually edit BUILD files before running `bazel run gazelle`
+- **BUILD files:** Never manually edit BUILD files before running `bazel run //:gazelle`
 - **Verification:** Run `aspect build //...` to verify changes don't break the build
 - **Security:** NEVER hardcode secrets/credentials; use environment variables
 
@@ -239,7 +239,7 @@ bazel clean && aspect build //...
 **Conventions:**
 
 - Use `# keep` comments for lines that shouldn't be auto-modified by Gazelle
-- Run `bazel run gazelle` before manual edits to BUILD files
+- Run `bazel run //:gazelle` before manual edits to BUILD files
 - Verify changes: `aspect build //path/to/package/...`
 
 ## 3. Repository Structure
@@ -264,7 +264,7 @@ bazel-repo/
 ## 4. Development Workflow
 
 1. Make code changes in appropriate project directory
-2. **Run Gazelle immediately:** `bazel run gazelle` (REQUIRED after ANY source file edit)
+2. **Run Gazelle immediately:** `bazel run //:gazelle` (REQUIRED after ANY source file edit)
 3. **Format code:** `aspect format --scope=all` (handles all languages)
 4. **Run tests:** `aspect test //path/to/tests` or `aspect test //...`
 5. **Test locally:** Use project-specific run commands (see subproject AGENTS.md)
@@ -302,7 +302,7 @@ bazel run @pnpm -- --dir $PWD install
 go get <package> && bazel mod tidy
 
 # BUILD files out of sync
-bazel run gazelle
+bazel run //:gazelle
 
 # Bazel not found
 which bazel  # Should point to bazelisk
@@ -318,9 +318,9 @@ cd predix && sqlc generate
 
 - ❌ Using `cargo build/test` instead of `aspect build/test`
 - ❌ Using `npm install` instead of `bazel run @pnpm -- --dir $PWD install`
-- ❌ Forgetting to run `bazel run gazelle` immediately after editing source files
-- ❌ Running `aspect format` before running `bazel run gazelle`
-- ❌ Editing BUILD files before running `bazel run gazelle`
+- ❌ Forgetting to run `bazel run //:gazelle` immediately after editing source files
+- ❌ Running `aspect format` before running `bazel run //:gazelle`
+- ❌ Editing BUILD files before running `bazel run //:gazelle`
 - ❌ Forgetting to run `aspect format --scope=all` before committing
 - ❌ Hardcoding secrets instead of using environment variables
 - ❌ Creating new directories without understanding the project structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ aspect format
 aspect format --scope=all
 
 # Regenerate BUILD files after editing source files
-bazel run gazelle
+bazel run //:gazelle
 
 # Install/sync NPM deps
 bazel run @pnpm -- --dir $PWD install
@@ -64,7 +64,7 @@ bazel test //... --config=remote-linux
 
 ### After editing source files, always:
 
-1. `bazel run gazelle` — regenerates BUILD files (must run before formatting)
+1. `bazel run //:gazelle` — regenerates BUILD files (must run before formatting)
 2. `aspect format --scope=all` — formats all code
 3. `aspect build //...` — verifies the build
 
@@ -172,7 +172,7 @@ Angular 21 projects live in `angular/projects/` (mindreadr, nicknamer, predix, t
 
 ### BUILD files
 
-- Always run `bazel run gazelle` before manually editing
+- Always run `bazel run //:gazelle` before manually editing
 - Use `# keep` comments to prevent Gazelle from modifying specific lines
 - Gazelle extensions: Go, Kotlin (contrib_rules_jvm), Rust (gazelle_rust), Skylib
 

--- a/clojure_sample/AGENTS.md
+++ b/clojure_sample/AGENTS.md
@@ -26,7 +26,7 @@ bazel test //clojure_sample/test/lowkeylab/clojure_sample:core_test.test --test_
 - Edit source files under `clojure_sample/src/` and tests under `clojure_sample/test/`.
 - Do not manually edit generated `BUILD.bazel` files below `clojure_sample/src/` or `clojure_sample/test/`.
 - After changing Clojure namespaces, `deps.edn`, or namespace dependencies, run `bazel run //:clojure_gen_build_files`.
-- Follow repository workflow: run `bazel run gazelle` after source edits, then `aspect format --scope=all`, then targeted build/test checks.
+- Follow repository workflow: run `bazel run //:gazelle` after source edits, then `aspect format --scope=all`, then targeted build/test checks.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- update active repository instructions to use the repository-absolute `//:gazelle` target
- allow the documented Gazelle command to work from nested directories
- leave historical plans unchanged

## Verification
- `bazel query //:gazelle` from `kafka_calculator/`
- `bazel run //:gazelle` from `kafka_calculator/`
- `aspect format --scope=all`
- `git diff --check`